### PR TITLE
Moved to Scala 2.13

### DIFF
--- a/casdb/pom.xml
+++ b/casdb/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.12</artifactId>
+            <artifactId>scala-xml_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/casdb/src/main/scala/edu/gemini/cas/db/Main.scala
+++ b/casdb/src/main/scala/edu/gemini/cas/db/Main.scala
@@ -5,7 +5,7 @@ package edu.gemini.cas.db
  * Loans the code for options processing from gds-config-validator
  */
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]):Unit = {
     val usage = """Usage: ./casdb.sh [-f|--file filename]
 """
     if (args.length == 0) {
@@ -21,10 +21,10 @@ object Main {
       list match {
         case Nil => map
         case "--file" :: value :: tail => {
-          nextOption(map ++ Map('file -> value), tail)
+          nextOption(map ++ Map(Symbol("file") -> value), tail)
         }
         case "-f" :: value :: tail => {
-          nextOption(map ++ Map('file -> value), tail)
+          nextOption(map ++ Map(Symbol("file") -> value), tail)
         }
         case option :: tail if isSwitch(option) => {
           println("Unknown option: " + option);
@@ -41,10 +41,10 @@ object Main {
     }
     val options = nextOption(Map(), arglist)
 
-    if (options.getOrElse('help, false) == true) {
+    if (options.getOrElse(Symbol("help"), false) == true) {
       println(usage)
     } else {
-      options.get('file) map {
+      options.get(Symbol("file")) map {
         case x: String => new ChannelBuilder(x)
         case _ =>
       }

--- a/casdb/src/test/scala/edu/gemini/cas/db/ChannelBuilderTest.scala
+++ b/casdb/src/test/scala/edu/gemini/cas/db/ChannelBuilderTest.scala
@@ -5,10 +5,10 @@ import org.junit.Assert._
 
 class ChannelBuilderTest {
   @Test
-  def testParser() {
+  def testParser():Unit = {
     val testFile = classOf[ChannelBuilder].getResource("channels.xml").toURI.toURL.getFile
     val channels = new ChannelBuilder(testFile).channels
-    
+
     assertNotNull(channels)
     assertEquals(5, channels.size)
     assertEquals("gpi:E1", channels(0).getName)

--- a/epics-service/src/test/java/edu/gemini/epics/impl/ChannelBindingSupportTest.java
+++ b/epics-service/src/test/java/edu/gemini/epics/impl/ChannelBindingSupportTest.java
@@ -21,8 +21,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/epics-service/src/test/java/edu/gemini/epics/impl/EpicsClientSubscriberTest.java
+++ b/epics-service/src/test/java/edu/gemini/epics/impl/EpicsClientSubscriberTest.java
@@ -10,10 +10,10 @@ import edu.gemini.epics.EpicsService;
 import gov.aps.jca.event.ConnectionListener;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -35,7 +35,7 @@ public class EpicsClientSubscriberTest {
         jcaContext = mock(CAJContext.class);
 
         CAJChannel channel = mock(CAJChannel.class);
-        when(jcaContext.createChannel(Matchers.<String>any(), Matchers.<ConnectionListener>anyObject())).thenReturn(channel);
+        when(jcaContext.createChannel(anyString(), any(ConnectionListener.class))).thenReturn(channel);
 
         epicsService = new EpicsService(jcaContext);
         epicsObserver = new EpicsObserverImpl(epicsService);

--- a/epics-service/src/test/java/edu/gemini/epics/impl/EpicsObserverImplTest.java
+++ b/epics-service/src/test/java/edu/gemini/epics/impl/EpicsObserverImplTest.java
@@ -20,16 +20,12 @@ import gov.aps.jca.event.MonitorListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 public class EpicsObserverImplTest {
     private static final ImmutableList<String> CHANNELS_TO_READ = ImmutableList.of("tst:tst2");
@@ -54,7 +50,7 @@ public class EpicsObserverImplTest {
         when(contextController.getJCAContext()).thenReturn(jcaContext);
 
         channel = mock(CAJChannel.class);
-        when(jcaContext.createChannel(Matchers.<String>any(), Matchers.<ConnectionListener>anyObject())).thenReturn(channel);
+        when(jcaContext.createChannel(anyString(), any(ConnectionListener.class))).thenReturn(channel);
         when(channel.getContext()).thenReturn(jcaContext);
     }
 
@@ -69,7 +65,7 @@ public class EpicsObserverImplTest {
 
     private void verifyChannelsAreRegisteredToClient(EpicsClientMock epicsClient) throws CAException {
         assertTrue(epicsClient.wasConnectedCalled());
-        verify(jcaContext).createChannel(eq("tst:tst2"), Matchers.<ConnectionListener>anyObject());
+        verify(jcaContext).createChannel(eq("tst:tst2"), any(ConnectionListener.class));
     }
 
     @Test
@@ -133,7 +129,7 @@ public class EpicsObserverImplTest {
 
     private void verifyNoInteractionsWithClient(EpicsClientMock epicsClient) {
         assertFalse(epicsClient.wasConnectedCalled());
-        verifyZeroInteractions(jcaContext);
+        verifyNoInteractions(jcaContext);
     }
 
     @Test
@@ -189,7 +185,7 @@ public class EpicsObserverImplTest {
         EpicsClient epicsClient = mock(EpicsClient.class);
         epicsObserver.unregisterEpicsClient(epicsClient);
 
-        verifyZeroInteractions(epicsClient);
+        verifyNoInteractions(epicsClient);
     }
 
 }

--- a/gds-actors-composer/src/main/scala/edu/gemini/aspen/gds/actors/KeywordSetComposer.scala
+++ b/gds-actors-composer/src/main/scala/edu/gemini/aspen/gds/actors/KeywordSetComposer.scala
@@ -29,14 +29,14 @@ class KeywordSetComposer(actorsFactory: KeywordActorsFactory, keywordsDatabase: 
   // Start automatically
   start()
 
-  def act() {
+  def act():Unit = {
     react {
       case AcquisitionRequest(obsEvent, dataLabel) => doCollection(sender, obsEvent, dataLabel)
       case _ => sys.error("Unknown request type ")
     }
   }
 
-  private def doCollection(sender: OutputChannel[Any], obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  private def doCollection(sender: OutputChannel[Any], obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     LOG.info(s"Starting keyword collection on dataset $dataLabel for event ${obsEvent.name}")
 
     val s = System.currentTimeMillis()
@@ -70,7 +70,7 @@ class KeywordSetComposer(actorsFactory: KeywordActorsFactory, keywordsDatabase: 
     dataFutures
   }
 
-  private def waitForDataAndReply(dataLabel: DataLabel, dataFutures: immutable.List[Future[Any]])(postAction: => Unit) {
+  private def waitForDataAndReply(dataLabel: DataLabel, dataFutures: immutable.List[Future[Any]])(postAction: => Unit):Unit = {
     measureDuration("Waiting for " + dataFutures.size + " data items ") {
       // Wait for response
       val v = Futures.awaitAll(5000, dataFutures: _*).collect {

--- a/gds-actors-composer/src/main/scala/edu/gemini/aspen/gds/actors/factory/CompositeActorsFactoryImpl.scala
+++ b/gds-actors-composer/src/main/scala/edu/gemini/aspen/gds/actors/factory/CompositeActorsFactoryImpl.scala
@@ -21,7 +21,7 @@ class CompositeActorsFactoryImpl(configService: GDSConfigurationService) extends
   //this had to be added for the epics factory. Channels take time to connect, so we want them early
   configure(actorsConfiguration)
 
-  override def configure(configuration: immutable.List[GDSConfiguration]) {
+  override def configure(configuration: immutable.List[GDSConfiguration]):Unit = {
     // Configure each factory in the composite
     factories foreach {
       _.configure(configuration)

--- a/gds-actors-composer/src/test/scala/edu/gemini/aspen/gds/actors/ConfigurableActorsFactory.scala
+++ b/gds-actors-composer/src/test/scala/edu/gemini/aspen/gds/actors/ConfigurableActorsFactory.scala
@@ -14,7 +14,7 @@ class ConfigurableActorsFactory extends AbstractKeywordActorsFactory {
     }
   }
 
-  override def configure(configuration: List[GDSConfiguration]) {
+  override def configure(configuration: List[GDSConfiguration]):Unit = {
     actorsConfiguration = configuration
   }
 }

--- a/gds-actors-composer/src/test/scala/edu/gemini/aspen/gds/actors/DummyActorsFactory.scala
+++ b/gds-actors-composer/src/test/scala/edu/gemini/aspen/gds/actors/DummyActorsFactory.scala
@@ -13,6 +13,6 @@ class DummyActorsFactory extends AbstractKeywordActorsFactory {
     immutable.List(dummyActor)
   }
 
-  override def configure(configuration: List[GDSConfiguration]) {}
+  override def configure(configuration: List[GDSConfiguration]):Unit = {}
 }
 

--- a/gds-actors-composer/src/test/scala/edu/gemini/aspen/gds/actors/KeywordSetComposerTest.scala
+++ b/gds-actors-composer/src/test/scala/edu/gemini/aspen/gds/actors/KeywordSetComposerTest.scala
@@ -10,7 +10,7 @@ import org.junit.Test
 
 class KeywordSetComposerTest {
   @Test
-  def startAcqMessage() {
+  def startAcqMessage():Unit = {
     val (dataLabel, composer) = createFixture
 
     // Send an init message
@@ -26,7 +26,7 @@ class KeywordSetComposerTest {
   }
 
   @Test
-  def endAcqMessage() {
+  def endAcqMessage():Unit = {
     val (dataLabel, composer) = createFixture
 
     // Send an init message
@@ -42,7 +42,7 @@ class KeywordSetComposerTest {
   }
 
   @Test
-  def testNoActors() {
+  def testNoActors():Unit = {
     // Generate datalabel
     val dataLabel = new DataLabel("GS-2011")
 
@@ -66,7 +66,7 @@ class KeywordSetComposerTest {
   }
 
   @Test
-  def testExceptionActor() {
+  def testExceptionActor():Unit = {
     // Generate dataset
     val dataLabel = new DataLabel("GS-2011")
 
@@ -96,7 +96,7 @@ class KeywordSetComposerTest {
   }
 
   @Test
-  def testExceptionActorFactory() {
+  def testExceptionActorFactory():Unit = {
     // Generate dataset
     val dataLabel = new DataLabel("GS-2011")
 

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/CompositePostProcessingPolicy.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/CompositePostProcessingPolicy.scala
@@ -30,18 +30,18 @@ class CompositePostProcessingPolicyImpl extends DefaultPostProcessingPolicy with
     }
   }
 
-  override def fileReady(originalFile: File, processedFile: File) {
+  override def fileReady(originalFile: File, processedFile: File):Unit = {
     val sortedPolicies = policies.sortWith((a, b) => a.priority < b.priority)
     for {
       p <- sortedPolicies
     } yield p.fileReady(originalFile, processedFile)
   }
 
-  def addPolicy(ep: PostProcessingPolicy) {
+  def addPolicy(ep: PostProcessingPolicy):Unit = {
     policies = ep :: policies
   }
 
-  def removePolicy(ep: PostProcessingPolicy) {
+  def removePolicy(ep: PostProcessingPolicy):Unit = {
     policies = policies.filter(_ != ep)
   }
 

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/KeywordActorsFactory.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/KeywordActorsFactory.scala
@@ -19,7 +19,7 @@ trait KeywordActorsFactory {
   /**
    * Passes the global GDS configuration along
    */
-  def configure(configuration: immutable.List[GDSConfiguration]) {
+  def configure(configuration: immutable.List[GDSConfiguration]):Unit = {
     actorsConfiguration = configuration filter {
       _.subsystem.name == getSource
     }

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/KeywordValueActor.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/KeywordValueActor.scala
@@ -17,7 +17,7 @@ case object Collect
 trait KeywordValueActor extends ActWithStash {
   ActorDSL.actor(this)
 
-  override def act() {
+  override def act():Unit = {
     react {
       case Collect => reply(collectValues())
     }

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/PostProcessingPolicy.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/PostProcessingPolicy.scala
@@ -41,5 +41,5 @@ class DefaultPostProcessingPolicy extends PostProcessingPolicy {
   // Let all the original headers to be applied
   override def applyPolicy(dataLabel: DataLabel, headers: immutable.List[CollectedValue[_]]): immutable.List[CollectedValue[_]] = headers
 
-  override def fileReady(originalFile: File, processedFile: File) {}
+  override def fileReady(originalFile: File, processedFile: File):Unit = {}
 }

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/Predef.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/Predef.scala
@@ -33,7 +33,7 @@ object Predef {
    * Utility method to wrap a method applied in an object that has a close method.
    * The close method is closed after the block is called
    */
-  def use[T <: {def close() : Unit}](closable: T)(block: T => Unit) {
+  def use[T <: {def close() : Unit}](closable: T)(block: T => Unit):Unit = {
     try {
       block(closable)
     } finally {

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/configuration/GDSConfigurationFile.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/configuration/GDSConfigurationFile.scala
@@ -45,7 +45,7 @@ object GDSConfigurationFile {
     }
   }
 
-  def saveConfiguration(configurationFile: String, contents: List[ConfigItem[_]]) {
+  def saveConfiguration(configurationFile: String, contents: List[ConfigItem[_]]):Unit = {
     val newFile = new File(configurationFile)
     use(new BufferedWriter(new FileWriter(newFile))) {
       writer: BufferedWriter => for (configLine <- contents) {

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/configuration/GDSConfigurationService.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/configuration/GDSConfigurationService.scala
@@ -65,7 +65,7 @@ class GDSConfigurationServiceImpl(configurationFile: String) extends GDSConfigur
     GDSConfigurationFile.getConfiguration(configurationFile)
   }
 
-  def replaceConfiguration(config: List[GDSConfiguration]) {
+  def replaceConfiguration(config: List[GDSConfiguration]):Unit = {
     val newFile = new File(configurationFile)
     use(new BufferedWriter(new FileWriter(newFile))) {
       writer: BufferedWriter => for (configLine <- config) {
@@ -88,11 +88,11 @@ class GDSConfigurationServiceImpl(configurationFile: String) extends GDSConfigur
     GDSConfigurationFile.getFullConfiguration(configurationFile)
   }
 
-  def updateConfiguration(config: List[ConfigItem[_]]) {
+  def updateConfiguration(config: List[ConfigItem[_]]):Unit = {
     GDSConfigurationFile.saveConfiguration(configurationFile, config)
   }
 
-  def addConfiguration(config: List[GDSConfiguration]) {
+  def addConfiguration(config: List[GDSConfiguration]):Unit = {
     val newFile = new File(configurationFile)
     use(new BufferedWriter(new FileWriter(newFile, true))) {
       writer: BufferedWriter => for (configLine <- config) {

--- a/gds-api/src/main/scala/edu/gemini/aspen/gds/api/osgi/GDSConfigurationServiceFactory.scala
+++ b/gds-api/src/main/scala/edu/gemini/aspen/gds/api/osgi/GDSConfigurationServiceFactory.scala
@@ -37,7 +37,7 @@ class GDSConfigurationServiceFactory(context: BundleContext) extends ManagedServ
   }
 
   def stopServices(): Unit = {
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     for (pid <- existingServices.keySet) {
       deleted(pid)
     }

--- a/gds-api/src/test/scala/edu/gemini/aspen/gds/api/CollectedValueTest.scala
+++ b/gds-api/src/test/scala/edu/gemini/aspen/gds/api/CollectedValueTest.scala
@@ -10,7 +10,7 @@ import edu.gemini.aspen.gds.api.fits.FitsKeyword
 class CollectedValueTest {
 
   @Test
-  def testBuilding() {
+  def testBuilding():Unit = {
     // Build with string
     assertNotNull(CollectedValue("KEYWORD", "strValue", "comment", 0, None))
     // Build with int
@@ -22,7 +22,7 @@ class CollectedValueTest {
   }
 
   @Test
-  def testPatternMatchingString() {
+  def testPatternMatchingString():Unit = {
     // Build with string
     val cv = CollectedValue("KEYWORD", "strValue", "comment", 0, None)
     cv match {
@@ -37,7 +37,7 @@ class CollectedValueTest {
   }
 
   @Test
-  def testPatternMatchingInteger() {
+  def testPatternMatchingInteger():Unit = {
     // Build with string
     val cv = CollectedValue("KEYWORD", 99, "comment", 0, None)
     cv match {
@@ -52,7 +52,7 @@ class CollectedValueTest {
   }
 
   @Test
-  def testPatternMatchingDouble() {
+  def testPatternMatchingDouble():Unit = {
     // Build with string
     val cv = CollectedValue("KEYWORD", 1.1, "comment", 0, None)
     cv match {
@@ -67,7 +67,7 @@ class CollectedValueTest {
   }
 
   @Test
-  def testPatternMatchingBoolean() {
+  def testPatternMatchingBoolean():Unit = {
     // Build with string
     val cv = CollectedValue("KEYWORD", false, "comment", 0, None)
     cv match {
@@ -82,7 +82,7 @@ class CollectedValueTest {
   }
 
   @Test
-  def testPatternMatchingInList() {
+  def testPatternMatchingInList():Unit = {
     // Build with string
     val cv = CollectedValue("KEYWORD", 1.1, "comment", 0, None)
     val list = immutable.List(cv)
@@ -98,7 +98,7 @@ class CollectedValueTest {
   }
 
   @Test
-  def testPatternMatchingError() {
+  def testPatternMatchingError():Unit = {
     // Build with string
     val ev = ErrorCollectedValue("KEYWORD", CollectionError.MandatoryRequired, "comment", 0)
     assertTrue(ev.isError)

--- a/gds-api/src/test/scala/edu/gemini/aspen/gds/api/PostProcessingPolicyTest.scala
+++ b/gds-api/src/test/scala/edu/gemini/aspen/gds/api/PostProcessingPolicyTest.scala
@@ -5,13 +5,13 @@ import org.junit.Assert._
 import edu.gemini.aspen.gds.api.Conversions._
 import edu.gemini.aspen.giapi.data.DataLabel
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 class PostProcessingPolicyTest {
   val dataLabel = new DataLabel("some key")
 
   @Test
-  def testDefault() {
+  def testDefault():Unit = {
     val ep = new DefaultPostProcessingPolicy()
     val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: Nil
 
@@ -19,7 +19,7 @@ class PostProcessingPolicyTest {
   }
 
   @Test
-  def testComposite() {
+  def testComposite():Unit = {
     val ep = new CompositePostProcessingPolicyImpl()
     val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: ErrorCollectedValue("KEY2", CollectionError.GenericError, "comment", 0) :: Nil
 
@@ -27,7 +27,7 @@ class PostProcessingPolicyTest {
   }
 
   @Test
-  def testCompositeDefault() {
+  def testCompositeDefault():Unit = {
     val ep = new CompositePostProcessingPolicyImpl()
     val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: ErrorCollectedValue("KEY2", CollectionError.GenericError, "comment", 0) :: Nil
 
@@ -36,7 +36,7 @@ class PostProcessingPolicyTest {
   }
 
   @Test
-  def testCompositeDefaultTwice() {
+  def testCompositeDefaultTwice():Unit = {
     val ep = new CompositePostProcessingPolicyImpl()
     val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: ErrorCollectedValue("KEY2", CollectionError.GenericError, "comment", 0) :: Nil
 
@@ -46,7 +46,7 @@ class PostProcessingPolicyTest {
   }
 
   @Test
-  def testOrder() {
+  def testOrder():Unit = {
     val errPol1 = mock(classOf[PostProcessingPolicy])
     when(errPol1.priority).thenReturn(7)
 

--- a/gds-api/src/test/scala/edu/gemini/aspen/gds/api/configuration/GDSConfigurationServiceTest.scala
+++ b/gds-api/src/test/scala/edu/gemini/aspen/gds/api/configuration/GDSConfigurationServiceTest.scala
@@ -22,11 +22,11 @@ class GDSConfigurationServiceTest extends FunSuite {
   val NEW_CONFIG = "gds-keywords.conf.test"
   val TEST_DIR = "/tmp/"
 
-  protected def copyFile(fromResource: String, toAbsolute: String) {
+  protected def copyFile(fromResource: String, toAbsolute: String):Unit = {
     copy(new File(this.getClass.getResource(fromResource).toURI), new File(toAbsolute))
   }
 
-  protected def checkOriginalContent(config: List[GDSConfiguration]) {
+  protected def checkOriginalContent(config: List[GDSConfiguration]):Unit = {
     assertTrue(config.contains(GDSConfiguration("GPI", "OBS_END_ACQ", "AIRMASS", 0, "DOUBLE", false, "NONE", "EPICS", "ws:massAirmass", 0, "", "Mean airmass for the observation")))
     //todo: check for the rest of the items
   }

--- a/gds-config-validator/src/main/scala/edu/gemini/aspen/gds/config/GDSConfigValidator.scala
+++ b/gds-config-validator/src/main/scala/edu/gemini/aspen/gds/config/GDSConfigValidator.scala
@@ -10,7 +10,7 @@ class GDSConfigValidator extends GDSConfigurationParser {
 
 //options: -h, -f file, -p (print)
 object GDSConfigValidator {
-  def main(args: Array[String]) {
+  def main(args: Array[String]):Unit = {
 
     val usage = """
     Usage: ./gds-validator.sh [-h|--help] [-p|--print] [-f|--file filename]

--- a/gds-config-validator/src/test/scala/edu/gemini/aspen/gds/config/GDSConfigValidatorTest.scala
+++ b/gds-config-validator/src/test/scala/edu/gemini/aspen/gds/config/GDSConfigValidatorTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class GDSConfigValidatorTest {
   @Test
-  def dummy() {
+  def dummy():Unit = {
 
   }
 }

--- a/gds-constant-actors/pom.xml
+++ b/gds-constant-actors/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor_2.12</artifactId>
+            <artifactId>akka-actor_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/gds-constant-actors/src/test/scala/edu/gemini/aspen/gds/constant/ConstantActorTest.scala
+++ b/gds-constant-actors/src/test/scala/edu/gemini/aspen/gds/constant/ConstantActorTest.scala
@@ -10,13 +10,13 @@ import scala.collection._
 class ConstantActorTest {
 
   @Test
-  def testActor() {
+  def testActor():Unit = {
     val constActor = new ConstantActor(buildConfiguration("KEY1", "val1") :: buildConfiguration("KEY2", "val2") :: Nil)
     assertEquals(CollectedValue("KEY1", "val1", "COMMENT", 0, None) :: CollectedValue("KEY2", "val2", "COMMENT", 0, None) :: Nil, constActor.collectValues())
   }
 
   @Test
-  def testQuoteRemoval() {
+  def testQuoteRemoval():Unit = {
     val constActor = new ConstantActor(GDSConfiguration("GPI",
         "OBS_START_ACQ",
         "KEY1",
@@ -45,7 +45,7 @@ class ConstantActorTest {
   }
 
   @Test
-  def testActorWrongType() {
+  def testActorWrongType():Unit = {
     val constActor = new ConstantActor(GDSConfiguration("GPI",
       "OBS_START_ACQ",
       "KEY1",
@@ -62,7 +62,7 @@ class ConstantActorTest {
   }
 
   @Test
-  def testActorOfBooleanType() {
+  def testActorOfBooleanType():Unit = {
     val constActor = new ConstantActor(GDSConfiguration("GPI",
       "OBS_START_ACQ",
       "KEY1",
@@ -79,7 +79,7 @@ class ConstantActorTest {
   }
 
   @Test
-  def testActorFactory() {
+  def testActorFactory():Unit = {
     val factory = new ConstantActorsFactory
     factory.configure(immutable.List(GDSConfiguration("GPI", "OBS_PREP", "TEST", 0, "DOUBLE", false, "1.0", "CONSTANT", "ws:massAirmass", 0, "", "my comment")))
 

--- a/gds-datalabel-provider/src/test/scala/edu/gemini/aspen/gds/datalabelprovider/DataLabelProviderTest.scala
+++ b/gds-datalabel-provider/src/test/scala/edu/gemini/aspen/gds/datalabelprovider/DataLabelProviderTest.scala
@@ -8,7 +8,7 @@ import edu.gemini.aspen.giapi.data.DataLabel
 class DataLabelProviderTest extends AssertionsForJUnit{
 
   @Test
-  def testBasic(){
+  def testBasic():Unit = {
     val dlp:DataLabelProvider = new DataLabelProviderImpl
     assert(dlp.getDataLabel() == new DataLabel("S20110505B0001"))
   }

--- a/gds-epics-actors/src/main/scala/edu/gemini/aspen/gds/epics/EpicsActorsFactory.scala
+++ b/gds-epics-actors/src/main/scala/edu/gemini/aspen/gds/epics/EpicsActorsFactory.scala
@@ -35,7 +35,7 @@ class EpicsActorsFactory(epicsReader: EpicsReader) extends AbstractKeywordActors
     (singleActors ++ arrayActors).toList
   }
 
-  override def configure(configuration: immutable.List[GDSConfiguration]) {
+  override def configure(configuration: immutable.List[GDSConfiguration]):Unit = {
     val oldConfig=actorsConfiguration.toSet
     super.configure(configuration)
     val newConfig = actorsConfiguration.toSet
@@ -70,7 +70,7 @@ class EpicsActorsFactory(epicsReader: EpicsReader) extends AbstractKeywordActors
 
   override def getSource = KeywordSource.EPICS
 
-  def unbindAllChannels() {
+  def unbindAllChannels():Unit = {
     channels.values.foreach {
       _.destroy()
     }

--- a/gds-epics-actors/src/test/scala/edu/gemini/aspen/gds/epics/EpicsArrayValuesActorTest.scala
+++ b/gds-epics-actors/src/test/scala/edu/gemini/aspen/gds/epics/EpicsArrayValuesActorTest.scala
@@ -8,7 +8,7 @@ import edu.gemini.aspen.gds.api.Conversions._
 import edu.gemini.aspen.gds.api._
 import edu.gemini.epics.api.ReadOnlyChannel
 import fits.FitsKeyword
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 class EpicsArrayValuesActorTest extends Mockito {
   val dataLabel = new DataLabel("GS-2011")
@@ -20,7 +20,7 @@ class EpicsArrayValuesActorTest extends Mockito {
 
 
   @Test
-  def testRight() {
+  def testRight():Unit = {
     // mock return value
     val ch = mock[ReadOnlyChannel[String]]
     ch.getAll returns referenceValue
@@ -49,7 +49,7 @@ class EpicsArrayValuesActorTest extends Mockito {
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def testWrongDatatype() {
+  def testWrongDatatype():Unit = {
     // mock return value
     val ch = mock[ReadOnlyChannel[String]]
 
@@ -61,7 +61,7 @@ class EpicsArrayValuesActorTest extends Mockito {
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def testWrongSource() {
+  def testWrongSource():Unit = {
     // mock return value
     val ch = mock[ReadOnlyChannel[String]]
 
@@ -73,7 +73,7 @@ class EpicsArrayValuesActorTest extends Mockito {
   }
 
   @Test
-  def testExceptionOnCollect() {
+  def testExceptionOnCollect():Unit = {
     // mock return value cannot be read
     val ch = mock[ReadOnlyChannel[String]]
     ch.getAll throws new RuntimeException
@@ -104,7 +104,7 @@ class EpicsArrayValuesActorTest extends Mockito {
   }
 
   @Test
-  def testOneCollectError() {
+  def testOneCollectError():Unit = {
     // mock return value
     val ch = mock[ReadOnlyChannel[String]]
     ch.getAll returns referenceValue

--- a/gds-epics-actors/src/test/scala/edu/gemini/aspen/gds/epics/EpicsValuesActorTest.scala
+++ b/gds-epics-actors/src/test/scala/edu/gemini/aspen/gds/epics/EpicsValuesActorTest.scala
@@ -8,7 +8,7 @@ import edu.gemini.aspen.gds.api.Conversions._
 import edu.gemini.aspen.gds.api._
 import edu.gemini.epics.api.ReadOnlyChannel
 import fits.FitsKeyword
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 class EpicsValuesActorTest extends Mockito {
   val dataLabel = new DataLabel("GS-2011")
@@ -22,7 +22,7 @@ class EpicsValuesActorTest extends Mockito {
     GDSConfiguration("GPI", "OBS_START_ACQ", "AIRMASS", 0, "STRING", mandatory, "NONE", "EPICS", channelName, arrayIndex, "", "Mean airmass for the observation")
 
   @Test
-  def testReplyToCollect() {
+  def testReplyToCollect():Unit = {
     val configuration = buildConfiguration(true, 0)
     // mock return value
     val ch = mock[ReadOnlyChannel[String]]
@@ -47,7 +47,7 @@ class EpicsValuesActorTest extends Mockito {
   }
 
   @Test
-  def testAccessArrayElement() {
+  def testAccessArrayElement():Unit = {
     val configuration = buildConfiguration(true, 1)
     // mock return value
     val ch = mock[ReadOnlyChannel[String]]
@@ -75,7 +75,7 @@ class EpicsValuesActorTest extends Mockito {
   // should not return anything if the value cannot be read. The default will be added by an PostProcessingPolicy
   // it doesn't matter at this point if the item is mandatory or not
   @Test
-  def testCollectingADefaultValue {
+  def testCollectingADefaultValue:Unit = {
     val configuration = buildConfiguration(false, 0)
     // mock return value cannot be read
     val ch = mock[ReadOnlyChannel[String]]
@@ -100,7 +100,7 @@ class EpicsValuesActorTest extends Mockito {
   // should not return anything if the value cannot be read. The default will be added by an PostProcessingPolicy
   // it doesn't matter at this point if the item is mandatory or not
   @Test
-  def testCollectError {
+  def testCollectError:Unit = {
     val configuration = buildConfiguration(true, 0)
     // mock return value cannot be read
     val ch = mock[ReadOnlyChannel[String]]
@@ -123,7 +123,7 @@ class EpicsValuesActorTest extends Mockito {
   }
 
   @Test
-  def testExceptionOnCollect {
+  def testExceptionOnCollect:Unit = {
     val configuration = buildConfiguration(true, 0)
     // mock return value cannot be read
     val ch = mock[ReadOnlyChannel[String]]
@@ -149,7 +149,7 @@ class EpicsValuesActorTest extends Mockito {
   }
 
   @Test
-  def testCollectTypeMismatch {
+  def testCollectTypeMismatch:Unit = {
     val configuration = GDSConfiguration("GPI", "OBS_START_ACQ", "AIRMASS", 0, "DOUBLE", true, "NONE", "EPICS", channelName, 0, "", "Mean airmass for the observation")
     val ch = mock[ReadOnlyChannel[String]]
     ch.getFirst returns "a string"
@@ -175,7 +175,7 @@ class EpicsValuesActorTest extends Mockito {
   }
 
   @Test
-  def testCollectTypeMismatchFromDoubleToInt {
+  def testCollectTypeMismatchFromDoubleToInt:Unit = {
     val configuration = GDSConfiguration("GPI", "OBS_START_ACQ", "AIRMASS", 0, "INT", true, "NONE", "EPICS", channelName, 0, "", "Mean airmass for the observation")
 
     val ch = mock[ReadOnlyChannel[java.lang.Double]]
@@ -204,7 +204,7 @@ class EpicsValuesActorTest extends Mockito {
   }
 
   @Test
-  def testArrayIndexOutOfBounds {
+  def testArrayIndexOutOfBounds:Unit = {
     val configuration = buildConfiguration(true, 2)
 
     val ch = mock[ReadOnlyChannel[String]]

--- a/gds-fits-checker/src/main/scala/edu/gemini/aspen/gds/fits/checker/InstrumentKeywordsChecker.scala
+++ b/gds-fits-checker/src/main/scala/edu/gemini/aspen/gds/fits/checker/InstrumentKeywordsChecker.scala
@@ -18,7 +18,7 @@ import scala.actors.Actor._
 class InstrumentKeywordsChecker(configService: GDSConfigurationService, obsState: ObservationStateRegistrar, propertyHolder: PropertyHolder) extends ObservationEventHandler {
   protected val LOG: Logger = Logger.getLogger(this.getClass.getName)
 
-  override def onObservationEvent(event: ObservationEvent, dataLabel: DataLabel) {
+  override def onObservationEvent(event: ObservationEvent, dataLabel: DataLabel):Unit = {
     event match {
       case ObservationEvent.OBS_END_DSET_WRITE => actor {
         checkMissing(dataLabel, configService.getConfiguration)
@@ -27,9 +27,9 @@ class InstrumentKeywordsChecker(configService: GDSConfigurationService, obsState
     }
   }
 
-  private[checker] def checkMissing(label: DataLabel, config: List[GDSConfiguration]) {
+  private[checker] def checkMissing(label: DataLabel, config: List[GDSConfiguration]):Unit = {
     val file = new File(propertyHolder.getProperty("DHS_SCIENCE_DATA_PATH"), label.toString)
-    
+
     LOG.info("Verifying original keywords of " + file)
     val readerOpt: Option[FitsReader] = try {
       Some(new FitsReader(file))

--- a/gds-fits-checker/src/test/scala/edu/gemini/aspen/gds/fits/checker/InstrumentKeywordCheckerTest.scala
+++ b/gds-fits-checker/src/test/scala/edu/gemini/aspen/gds/fits/checker/InstrumentKeywordCheckerTest.scala
@@ -3,7 +3,7 @@ package edu.gemini.aspen.gds.fits.checker
 import java.io.File
 import edu.gemini.aspen.gds.api.GDSConfiguration
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import edu.gemini.aspen.gds.observationstate.ObservationStateRegistrar
 import edu.gemini.aspen.gds.api.Conversions._
 import collection.immutable.Set
@@ -47,7 +47,7 @@ class InstrumentKeywordCheckerTest extends FunSuite with BeforeAndAfter with Moc
 
     checker.onObservationEvent(ObservationEvent.OBS_END_DSET_WRITE, "sample.fits")
     TimeUnit.MILLISECONDS.sleep(200)
-    verifyZeroInteractions(obsState)
+    verifyNoInteractions(obsState)
   }
 
   test("check without extension, bug GIAPI-932"){
@@ -59,7 +59,7 @@ class InstrumentKeywordCheckerTest extends FunSuite with BeforeAndAfter with Moc
 
     checker.onObservationEvent(ObservationEvent.OBS_END_DSET_WRITE, "sample")
     TimeUnit.MILLISECONDS.sleep(200)
-    verifyZeroInteractions(obsState)
+    verifyNoInteractions(obsState)
   }
 
   after {

--- a/gds-fits-updater/src/main/scala/edu/gemini/aspen/gds/fits/FitsReader.scala
+++ b/gds-fits-updater/src/main/scala/edu/gemini/aspen/gds/fits/FitsReader.scala
@@ -1,7 +1,7 @@
 package edu.gemini.aspen.gds.fits
 
 import java.io.File
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import java.util.logging.Logger
 import nom.tam.fits.{HeaderCard, Fits}
 import edu.gemini.aspen.gds.api.fits.{HeaderItem, FitsKeyword, Header}

--- a/gds-fits-updater/src/main/scala/edu/gemini/aspen/gds/fits/FitsUpdater.scala
+++ b/gds-fits-updater/src/main/scala/edu/gemini/aspen/gds/fits/FitsUpdater.scala
@@ -44,7 +44,7 @@ class FitsUpdater(fromDirectory: File, toDirectory: File, dataLabel: DataLabel, 
   })
   start()
 
-  def act() {
+  def act():Unit = {
     loop {
       react {
         case Update(namingFunction) => {

--- a/gds-fits-updater/src/main/scala/edu/gemini/aspen/gds/fits/FitsWriter.scala
+++ b/gds-fits-updater/src/main/scala/edu/gemini/aspen/gds/fits/FitsWriter.scala
@@ -2,7 +2,7 @@ package edu.gemini.aspen.gds.fits
 
 import edu.gemini.aspen.gds.api.fits.Header
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import edu.gemini.aspen.gds.api.Conversions._
 import com.google.common.base.Stopwatch
 import nom.tam.util.BufferedFile
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit
 class FitsWriter(file: File) extends FitsReader(file) {
   traverseHeaders(0)
 
-  private def addNewKeywords(hdu: BasicHDU, header: Header) {
+  private def addNewKeywords(hdu: BasicHDU, header: Header):Unit = {
     val hduHeader = hdu.getHeader
     val existingKeywords = hduHeader.iterator().collect {
       case k: HeaderCard if k.isKeyValuePair => k
@@ -117,7 +117,7 @@ class FitsWriter(file: File) extends FitsReader(file) {
     }
   }
 
-  private def validateValue(value: String) {
+  private def validateValue(value: String):Unit = {
     if (value.length() > HeaderCard.MAX_VALUE_LENGTH) {
       throw new IllegalArgumentException()
     } else if (value.startsWith("'") && !value.endsWith("'")) {
@@ -125,7 +125,7 @@ class FitsWriter(file: File) extends FitsReader(file) {
     }
   }
 
-  private def commitChanges(destinationFile: File) {
+  private def commitChanges(destinationFile: File):Unit = {
     val stopwatch = Stopwatch.createStarted()
 
     Files.createParentDirs(destinationFile)
@@ -139,7 +139,7 @@ class FitsWriter(file: File) extends FitsReader(file) {
    * Updates the FITS file with new keywords add to the header
    * In case the header does not exist the operation is ignored
    * Existing keywords are not updated */
-  def updateHeader(header: Header, destinationFile: File) {
+  def updateHeader(header: Header, destinationFile: File):Unit = {
     Option(fitsFile.getHDU(header.index)) foreach {
       hdu =>
         addNewKeywords(hdu, header)
@@ -151,7 +151,7 @@ class FitsWriter(file: File) extends FitsReader(file) {
    * Updates the FITS file with new keywords added to several headers at a time
    * In case the header does not exist the operation is ignored
    * Existing keywords are not updated */
-  def updateHeaders(headers: Traversable[Header], destinationFile: File) {
+  def updateHeaders(headers: Traversable[Header], destinationFile: File):Unit = {
     headers foreach {
       h => if (fitsFile.getHDU(h.index) != null) addNewKeywords(fitsFile.getHDU(h.index), h)
     }
@@ -159,7 +159,7 @@ class FitsWriter(file: File) extends FitsReader(file) {
   }
 
   @tailrec
-  private def traverseHeaders(index: Int) {
+  private def traverseHeaders(index: Int):Unit = {
     if (fitsFile.getHDU(index) != null) {
       traverseHeaders(index + 1)
     }

--- a/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsBaseTest.scala
+++ b/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsBaseTest.scala
@@ -19,15 +19,15 @@ trait FitsBaseTest extends FunSuite with BeforeAndAfterEach {
     fitsUpdater.updateFitsHeaders(outputNamingFunction = label => destinationFile.getName)
   }
 
-  def verifyKeywordInHeader(header: Header, keyword: String) {
+  def verifyKeywordInHeader(header: Header, keyword: String):Unit = {
     assertTrue(header.containsKey(keyword))
   }
 
-  def verifyKeywordNotInHeader(header: Header, keyword: String) {
+  def verifyKeywordNotInHeader(header: Header, keyword: String):Unit = {
     assertFalse(header.containsKey(keyword))
   }
 
-  override def afterEach() = if (destinationFile.exists) {
+  override def afterEach(): Unit = if (destinationFile.exists):Unit = {
     destinationFile.delete
   }
 }

--- a/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsReaderTest.scala
+++ b/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsReaderTest.scala
@@ -15,7 +15,7 @@ class FitsReaderTest extends FunSuite with FitsSamplesDownloader with FitsSample
     downloadFile("test1546.fits", "527b8899b9eb65fec92350626d2232ee")
   }
 
-  def verifyKeysInHeader(header: Header, names: List[String]) {
+  def verifyKeysInHeader(header: Header, names: List[String]):Unit = {
     val keyNames = header.keywords map {
       _.keywordName.key
     }

--- a/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsSamplesDownloader.scala
+++ b/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsSamplesDownloader.scala
@@ -7,7 +7,7 @@ import com.google.common.io.{Closer, Closeables, ByteStreams, Files}
 
 trait FitsSamplesDownloader {
   // Check if file is available and md5 hashes matches
-  def downloadFile(fileName: String, fileHash: String) {
+  def downloadFile(fileName: String, fileHash: String):Unit = {
     val sampleFile = new File(fileName)
     val hashingFunction = Hashing.md5()
     val available = sampleFile.exists() && hashingFunction.hashBytes(Files.toByteArray(sampleFile)).toString == fileHash

--- a/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsWriterDataTypesTest.scala
+++ b/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsWriterDataTypesTest.scala
@@ -13,7 +13,7 @@ import edu.gemini.aspen.gds.api.FitsType
 class FitsWriterDataTypesTest extends FunSuite with BeforeAndAfterEach {
   val destFile = File.createTempFile("test", ".fits")
 
-  override def afterEach() {
+  override def afterEach():Unit = {
     if (destFile.exists()) destFile.delete()
   }
 

--- a/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsWriterTest.scala
+++ b/gds-fits-updater/src/test/scala/edu/gemini/aspen/gds/fits/FitsWriterTest.scala
@@ -19,7 +19,7 @@ class FitsWriterTest extends FunSuite with FitsSamplesDownloader with FitsSample
 
   val destFile = File.createTempFile("test", ".fits")
 
-  override def afterEach() {
+  override def afterEach():Unit = {
     if (destFile.exists()) destFile.delete()
   }
 
@@ -27,7 +27,7 @@ class FitsWriterTest extends FunSuite with FitsSamplesDownloader with FitsSample
   def createHeadersWithAirMass(headerIndex: Int): Header = Header(headerIndex, List(HeaderItem("AIRMASS", 1.0, "Mass of airmass", None)))
 
   // Verifies that a header contains all the original keywords plus new keywords
-  def verifyKeysInHeader(header: Header, names: List[String], newKeywords: List[String]) {
+  def verifyKeysInHeader(header: Header, names: List[String], newKeywords: List[String]):Unit = {
     val keyNames = header.keywords map {
       _.keywordName.key
     }

--- a/gds-health/src/main/scala/edu/gemini/aspen/gds/health/GdsHealth.scala
+++ b/gds-health/src/main/scala/edu/gemini/aspen/gds/health/GdsHealth.scala
@@ -29,49 +29,49 @@ class GdsHealth(top: Top, setter: StatusSetter) extends JmsArtifact {
   private val stateActor = new StateActor()
   stateActor.start()
 
-  private def updateHealth() {
+  private def updateHealth():Unit = {
     LOG.info(s"Updating Health to ${healthState.getHealth} on $healthName")
     stateActor ! UpdateHealth
   }
 
-  def stopJms() {}
+  def stopJms():Unit = {}
 
-  def startJms(provider: JmsProvider) {
+  def startJms(provider: JmsProvider):Unit = {
     LOG.info("Start GDS Health")
     stateActor ! Connected
   }
 
-  def bindHeaderReceiver() {
+  def bindHeaderReceiver():Unit = {
     LOG.fine("Binding HeaderReceiver")
     healthState.registerHeaderReceiver()
     updateHealth()
   }
 
-  def unbindHeaderReceiver() {
+  def unbindHeaderReceiver():Unit = {
     LOG.fine("Unbinding HeaderReceiver")
     healthState.unregisterHeaderReceiver()
     updateHealth()
   }
 
-  def bindGDSObseventHandler(evtHndlr: GDSObseventHandler) {
+  def bindGDSObseventHandler(evtHndlr: GDSObseventHandler):Unit = {
     LOG.fine("Binding GDSObseventHandlerImpl")
     healthState.registerGDSObseventHandler()
     updateHealth()
   }
 
-  def unbindGDSObseventHandler(evtHndlr: GDSObseventHandler) {
+  def unbindGDSObseventHandler(evtHndlr: GDSObseventHandler):Unit = {
     LOG.fine("Unbinding GDSObseventHandlerImpl")
     healthState.unregisterGDSObseventHandler()
     updateHealth()
   }
 
-  def bindActorFactory(fact: KeywordActorsFactory) {
+  def bindActorFactory(fact: KeywordActorsFactory):Unit = {
     LOG.fine("Binding ActorsFactory: " + fact.getClass.getName)
     healthState.registerActorFactory(fact.getSource)
     updateHealth()
   }
 
-  def unbindActorFactory(fact: KeywordActorsFactory) {
+  def unbindActorFactory(fact: KeywordActorsFactory):Unit = {
     LOG.fine("Unbinding ActorsFactory: " + fact.getClass.getName)
     healthState.unregisterActorFactory(fact.getSource)
     updateHealth()
@@ -80,7 +80,7 @@ class GdsHealth(top: Top, setter: StatusSetter) extends JmsArtifact {
   class StateActor extends Actor {
     var connected = false
 
-    override def act() {
+    override def act():Unit = {
       loop {
         react {
           case Connected                 =>
@@ -95,7 +95,7 @@ class GdsHealth(top: Top, setter: StatusSetter) extends JmsArtifact {
       }
     }
 
-    def updateHealthValues() {
+    def updateHealthValues():Unit = {
       setter.setStatusItem(new HealthStatus(healthName, healthState.getHealth))
       setter.setStatusItem(new BasicStatus[String](healthMessageName, healthState.getMessage))
       LOG.info("GDS health SET " + healthState)
@@ -109,30 +109,30 @@ class GdsHealth(top: Top, setter: StatusSetter) extends JmsArtifact {
     private var obsEvtHndl = false
     private var headerRec = false
 
-    def registerHeaderReceiver() {
+    def registerHeaderReceiver():Unit = {
       headerRec = true
     }
 
-    def unregisterHeaderReceiver() {
+    def unregisterHeaderReceiver():Unit = {
       headerRec = false
     }
 
-    def registerGDSObseventHandler() {
+    def registerGDSObseventHandler():Unit = {
       obsEvtHndl = true
     }
 
-    def unregisterGDSObseventHandler() {
+    def unregisterGDSObseventHandler():Unit = {
       obsEvtHndl = false
     }
 
-    def registerActorFactory(source: KeywordSource.Value) {
+    def registerActorFactory(source: KeywordSource.Value):Unit = {
       source match {
         case KeywordSource.NONE => LOG.fine(s"Registered KeywordActorsFactory of unknown type: $source")
         case x => actors(x.id) = true
       }
     }
 
-    def unregisterActorFactory(source: KeywordSource.Value) {
+    def unregisterActorFactory(source: KeywordSource.Value):Unit = {
       source match {
         case KeywordSource.NONE => LOG.fine(s"Unregistered KeywordActorsFactory of unknown type: $source")
         case x => actors(x.id) = false

--- a/gds-health/src/test/scala/edu/gemini/aspen/gds/health/GdsHealthTest.scala
+++ b/gds-health/src/test/scala/edu/gemini/aspen/gds/health/GdsHealthTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import edu.gemini.jms.activemq.provider.ActiveMQJmsProvider
 import edu.gemini.aspen.giapi.statusservice.{StatusHandlerAggregate, StatusService}
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import edu.gemini.aspen.giapi.status.{Health, StatusHandler, StatusItem}
 import edu.gemini.aspen.gds.api.{GDSObseventHandler, KeywordActorsFactory, KeywordSource}
 import java.util.concurrent.{CountDownLatch, TimeUnit}
@@ -42,7 +42,7 @@ class GdsHealthTest extends FunSuite with MockitoSugar with BeforeAndAfter {
     val latch = new CountDownLatch(retries)
     var lastHealthStatusItem: StatusItem[_] = _
 
-    override def update[T](item: StatusItem[T]) {
+    override def update[T](item: StatusItem[T]):Unit = {
       if (item.getName.equals(healthName)) {
         lastHealthStatusItem = item
 
@@ -51,7 +51,7 @@ class GdsHealthTest extends FunSuite with MockitoSugar with BeforeAndAfter {
       }
     }
 
-    def waitForCompletion() {
+    def waitForCompletion():Unit = {
       assertTrue(latch.await(5, TimeUnit.SECONDS))
     }
 
@@ -103,7 +103,7 @@ class GdsHealthTest extends FunSuite with MockitoSugar with BeforeAndAfter {
     agg.unbindStatusHandler(handler)
   }
 
-  def bindAllHealthSources(gdsHealth: GdsHealth) {
+  def bindAllHealthSources(gdsHealth: GdsHealth):Unit = {
     gdsHealth.bindGDSObseventHandler(mock[GDSObseventHandler])
     val fact = mock[KeywordActorsFactory]
     for (source <- KeywordSource.values - KeywordSource.NONE - KeywordSource.INSTRUMENT - KeywordSource.ODB) {

--- a/gds-instrument-status-actors/src/test/scala/edu/gemini/aspen/gds/status/InstrumentStatusActorTest.scala
+++ b/gds-instrument-status-actors/src/test/scala/edu/gemini/aspen/gds/status/InstrumentStatusActorTest.scala
@@ -18,7 +18,7 @@ class InstrumentStatusActorTest extends Mockito {
   val statusItemName = "gpi:status1"
 
   @Test
-  def testReplyToCollect {
+  def testReplyToCollect:Unit = {
     val configuration = buildConfiguration(statusItemName, false)
 
     val referenceValue = "ok"
@@ -48,7 +48,7 @@ class InstrumentStatusActorTest extends Mockito {
   // should not return anything if the value cannot be read. The default will be added by an PostProcessingPolicy
   // it doesn't matter at this point if the item is mandatory or not
   @Test
-  def testReplyToCollectIfStatusUnknown {
+  def testReplyToCollectIfStatusUnknown:Unit = {
     val configuration = buildConfiguration(statusItemName, false)
 
     // mock return value
@@ -71,7 +71,7 @@ class InstrumentStatusActorTest extends Mockito {
   // should not return anything if the value cannot be read. The default will be added by an PostProcessingPolicy
   // it doesn't matter at this point if the item is mandatory or not
   @Test
-  def testErrorMandatoryItemAndStatusUnknown {
+  def testErrorMandatoryItemAndStatusUnknown:Unit = {
     val configuration = buildConfiguration(statusItemName, true)
 
     // mock return value
@@ -92,7 +92,7 @@ class InstrumentStatusActorTest extends Mockito {
   }
 
   @Test
-  def testTypeMismatchError {
+  def testTypeMismatchError:Unit = {
     val configuration = GDSConfiguration("GPI",
       "OBS_START_ACQ",
       fitsKeyword,

--- a/gds-keywords-database/pom.xml
+++ b/gds-keywords-database/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor_2.12</artifactId>
+            <artifactId>akka-actor_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/gds-keywords-database/src/main/scala/edu/gemini/aspen/gds/keywords/database/impl/KeywordsDatabaseImpl.scala
+++ b/gds-keywords-database/src/main/scala/edu/gemini/aspen/gds/keywords/database/impl/KeywordsDatabaseImpl.scala
@@ -8,7 +8,7 @@ import edu.gemini.aspen.gds.api.CollectedValue
 import edu.gemini.aspen.gds.keywords.database._
 import edu.gemini.aspen.giapi.data.DataLabel
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.collection.concurrent
 
 /**
@@ -20,7 +20,7 @@ class KeywordsDatabaseImpl extends KeywordsDatabase {
 
   start()
 
-  def act() {
+  def act():Unit = {
     loop {
       react {
         case Store(dataLabel: DataLabel, value: CollectedValue[_])           => _store(dataLabel, List[CollectedValue[_]](value))
@@ -32,11 +32,11 @@ class KeywordsDatabaseImpl extends KeywordsDatabase {
     }
   }
 
-  def store(dataLabel: DataLabel, value: CollectedValue[_]) {
+  def store(dataLabel: DataLabel, value: CollectedValue[_]):Unit = {
     this ! Store(dataLabel, value)
   }
 
-  def storeList[T](dataLabel: DataLabel, value: List[CollectedValue[T]]) {
+  def storeList[T](dataLabel: DataLabel, value: List[CollectedValue[T]]):Unit = {
     this ! StoreList(dataLabel, value)
   }
 
@@ -45,7 +45,7 @@ class KeywordsDatabaseImpl extends KeywordsDatabase {
     ret.asInstanceOf[Option[List[CollectedValue[_]]]] getOrElse Nil
   }
 
-  def clean(dataLabel: DataLabel) {
+  def clean(dataLabel: DataLabel):Unit = {
     this ! Clean(dataLabel)
   }
 

--- a/gds-keywords-database/src/main/scala/edu/gemini/aspen/gds/keywords/database/impl/ProgramIdDatabaseImpl.scala
+++ b/gds-keywords-database/src/main/scala/edu/gemini/aspen/gds/keywords/database/impl/ProgramIdDatabaseImpl.scala
@@ -6,7 +6,7 @@ import com.google.common.cache.CacheBuilder
 import edu.gemini.aspen.gds.keywords.database.{ProgramIdDatabase, RetrieveProgramId, StoreProgramId}
 import edu.gemini.aspen.giapi.data.DataLabel
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.collection.concurrent
 
 /**
@@ -17,7 +17,7 @@ class ProgramIdDatabaseImpl extends ProgramIdDatabase {
 
   start()
 
-  def act() {
+  def act():Unit = {
     loop {
       react {
         case StoreProgramId(dataLabel, programId) => internalStore(dataLabel, programId)
@@ -31,11 +31,11 @@ class ProgramIdDatabaseImpl extends ProgramIdDatabase {
     .expireAfterWrite(expirationMillis, MILLISECONDS)
     .build[DataLabel, String]().asMap()
 
-  override def store(dataLabel: DataLabel, programId: String) {
+  override def store(dataLabel: DataLabel, programId: String):Unit = {
     this ! StoreProgramId(dataLabel, programId)
   }
 
-  private def internalStore(dataLabel: DataLabel, programId: String) {
+  private def internalStore(dataLabel: DataLabel, programId: String):Unit = {
     map += dataLabel -> programId
   }
 

--- a/gds-keywords-database/src/test/scala/edu/gemini/aspen/gds/keywords/database/impl/KeywordsDatabaseTest.scala
+++ b/gds-keywords-database/src/test/scala/edu/gemini/aspen/gds/keywords/database/impl/KeywordsDatabaseTest.scala
@@ -21,11 +21,11 @@ class KeywordsDatabaseTest extends AssertionsForJUnit {
   val dataLabel2 = "GS-2011A"
 
   @Before
-  def setup() {
+  def setup():Unit = {
     db = new KeywordsDatabaseImpl
   }
 
-  def check(label: DataLabel, item: CollectedValue[_]) {
+  def check(label: DataLabel, item: CollectedValue[_]):Unit = {
     val ret = db !?(1000, Retrieve(label))
     assertFalse(ret.isEmpty) //we didn't get a timeout
     ret foreach {
@@ -37,7 +37,7 @@ class KeywordsDatabaseTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testMethods() {
+  def testMethods():Unit = {
     db.store(dataLabel, colVal)
     val ret = db.retrieve(dataLabel)
     assertEquals(1, ret.size)
@@ -45,13 +45,13 @@ class KeywordsDatabaseTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testRetrieveAll() {
+  def testRetrieveAll():Unit = {
     db ! Store(dataLabel, colVal)
     check(dataLabel, colVal)
   }
 
 
-  def checkEmpty(ret: Option[Any]) {
+  def checkEmpty(ret: Option[Any]):Unit = {
     assertFalse(ret.isEmpty)
     ret map {
       case c: List[_] => assertTrue(c.isEmpty)
@@ -60,20 +60,20 @@ class KeywordsDatabaseTest extends AssertionsForJUnit {
   }
 
   @Test
-  def retrieveEmpty() {
+  def retrieveEmpty():Unit = {
     val ret = db !?(1000, Retrieve(dataLabel))
     checkEmpty(ret)
   }
 
   @Test
-  def retrieveWrongDataLabel() {
+  def retrieveWrongDataLabel():Unit = {
     db ! Store(dataLabel, colVal)
     val ret = db !?(1000, Retrieve("wrong"))
     checkEmpty(ret)
   }
 
   @Test
-  def multipleDatasets() {
+  def multipleDatasets():Unit = {
     db ! Store(dataLabel, colVal)
     db ! Store(dataLabel2, colVal2)
 
@@ -83,7 +83,7 @@ class KeywordsDatabaseTest extends AssertionsForJUnit {
   }
 
   @Test
-  def multipleDatasetsInList() {
+  def multipleDatasetsInList():Unit = {
     db ! StoreList(dataLabel, List(colVal, colVal2))
 
     check(dataLabel, colVal)
@@ -92,14 +92,14 @@ class KeywordsDatabaseTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testClean() {
+  def testClean():Unit = {
     db !?(1000, Retrieve(dataLabel))
     db ! Clean(dataLabel)
     retrieveEmpty()
   }
 
   @Test
-  def testExpiration() {
+  def testExpiration():Unit = {
     val db = new KeywordsDatabaseImpl {
       override def expirationMillis = 5
     }

--- a/gds-keywords-database/src/test/scala/edu/gemini/aspen/gds/keywords/database/impl/ProgramIdDatabaseTest.scala
+++ b/gds-keywords-database/src/test/scala/edu/gemini/aspen/gds/keywords/database/impl/ProgramIdDatabaseTest.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 
 class ProgramIdDatabaseTest extends AssertionsForJUnit {
   @Test
-  def testBasic() {
+  def testBasic():Unit = {
     val db = new ProgramIdDatabaseImpl
     db ! StoreProgramId("label", "id")
 
@@ -20,7 +20,7 @@ class ProgramIdDatabaseTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testExpiration() {
+  def testExpiration():Unit = {
     val db = new ProgramIdDatabaseImpl {
       override def expirationMillis = 5
     }

--- a/gds-observation-state-publisher/src/main/scala/edu/gemini/aspen/gds/observationstate/impl/InspectPolicy.scala
+++ b/gds-observation-state-publisher/src/main/scala/edu/gemini/aspen/gds/observationstate/impl/InspectPolicy.scala
@@ -23,13 +23,13 @@ class InspectPolicy(configService: GDSConfigurationService, obsState: Observatio
     headers
   }
 
-  private def checkErrors(label: DataLabel, headers: List[CollectedValue[_]]) {
+  private def checkErrors(label: DataLabel, headers: List[CollectedValue[_]]):Unit = {
     obsState.registerCollectionError(label, headers collect {
       case c: ErrorCollectedValue => (c.keyword, c.error)
     })
   }
 
-  private def checkMissing(label: DataLabel, headers: List[CollectedValue[_]]) {
+  private def checkMissing(label: DataLabel, headers: List[CollectedValue[_]]):Unit = {
     val configList = configService.getConfiguration filterNot {
       _.subsystem.name == KeywordSource.INSTRUMENT //IFS keywords are not written by us, they are already in the file
     }

--- a/gds-observation-state-publisher/src/main/scala/edu/gemini/aspen/gds/observationstate/impl/ObservationStateImpl.scala
+++ b/gds-observation-state-publisher/src/main/scala/edu/gemini/aspen/gds/observationstate/impl/ObservationStateImpl.scala
@@ -10,7 +10,7 @@ import edu.gemini.aspen.gds.api.{CollectedValue, CollectionError}
 import edu.gemini.aspen.gds.observationstate.{ObservationInfo, _}
 import edu.gemini.aspen.giapi.data.DataLabel
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.collection.concurrent._
 import scala.collection.mutable
 import scala.collection.mutable.{HashSet, Set, SynchronizedSet}
@@ -34,7 +34,7 @@ class ObservationStateImpl(obsStatePubl: ObservationStatePublisher) extends Obse
     .expireAfterWrite(expirationMillis, MILLISECONDS)
     .build[DataLabel, ObservationState]().asMap()
 
-  override def registerMissingKeyword(label: DataLabel, keywords: Traversable[FitsKeyword]) {
+  override def registerMissingKeyword(label: DataLabel, keywords: Traversable[FitsKeyword]):Unit = {
     obsInfoMap.getOrElseUpdate(label, new ObservationState).missingKeywords ++= keywords
     if (keywords.nonEmpty) {
       obsInfoMap.getOrElseUpdate(label, new ObservationState).inError = true
@@ -42,28 +42,28 @@ class ObservationStateImpl(obsStatePubl: ObservationStatePublisher) extends Obse
   }
 
   //todo: use cause for something
-  override def registerError(label: DataLabel, cause: String) {
+  override def registerError(label: DataLabel, cause: String):Unit = {
     obsInfoMap.getOrElseUpdate(label, new ObservationState).failed = true
     obsStatePubl.publishObservationError(ObservationInfo(label, ObservationError, errorMsg = Option(cause)))
   }
 
-  override def registerCollectionError(label: DataLabel, errors: Traversable[(FitsKeyword, CollectionError.CollectionError)]) {
+  override def registerCollectionError(label: DataLabel, errors: Traversable[(FitsKeyword, CollectionError.CollectionError)]):Unit = {
     obsInfoMap.getOrElseUpdate(label, new ObservationState).errorKeywords ++= errors
     if (errors.nonEmpty) {
       obsInfoMap.getOrElseUpdate(label, new ObservationState).inError = true
     }
   }
 
-  override def registerTimes(label: DataLabel, times: Traversable[(AnyRef, Option[Duration])]) {
+  override def registerTimes(label: DataLabel, times: Traversable[(AnyRef, Option[Duration])]):Unit = {
     obsInfoMap.getOrElseUpdate(label, new ObservationState).times ++= times
   }
 
-  override def endObservation(label: DataLabel, writeTime:Long, collectedValues: Traversable[CollectedValue[_]]) {
+  override def endObservation(label: DataLabel, writeTime:Long, collectedValues: Traversable[CollectedValue[_]]):Unit = {
     obsInfoMap.getOrElseUpdate(label, new ObservationState).ended = true
     obsStatePubl.publishEndObservation(ObservationInfo(label, Successful, writeTime = Some(writeTime), collectedValues = collectedValues))
   }
 
-  override def startObservation(label: DataLabel) {
+  override def startObservation(label: DataLabel):Unit = {
     obsInfoMap.getOrElseUpdate(label, new ObservationState).started = true
     obsStatePubl.publishStartObservation(label)
   }

--- a/gds-observation-state-publisher/src/main/scala/edu/gemini/aspen/gds/observationstate/impl/ObservationStatePublisherImpl.scala
+++ b/gds-observation-state-publisher/src/main/scala/edu/gemini/aspen/gds/observationstate/impl/ObservationStatePublisherImpl.scala
@@ -11,29 +11,29 @@ import scala.collection.mutable.{HashSet, Set, SynchronizedSet}
 class ObservationStatePublisherImpl extends ObservationStatePublisher {
   val registeredConsumers: Set[ObservationStateConsumer] = new HashSet[ObservationStateConsumer] with SynchronizedSet[ObservationStateConsumer]
 
-  def publishStartObservation(label: DataLabel) {
+  def publishStartObservation(label: DataLabel):Unit = {
     for (consumer <- registeredConsumers) {
       consumer.receiveStartObservation(label)
     }
   }
 
-  override def publishEndObservation(observationInfo: ObservationInfo) {
+  override def publishEndObservation(observationInfo: ObservationInfo):Unit = {
     registeredConsumers foreach {
       _.receiveEndObservation(observationInfo)
     }
   }
 
-  override def publishObservationError(observationInfo: ObservationInfo) {
+  override def publishObservationError(observationInfo: ObservationInfo):Unit = {
     registeredConsumers foreach {
       _.receiveObservationError(observationInfo)
     }
   }
 
-  def bindConsumer(consumer: ObservationStateConsumer) {
+  def bindConsumer(consumer: ObservationStateConsumer):Unit = {
     registeredConsumers += consumer
   }
 
-  def unbindConsumer(consumer: ObservationStateConsumer) {
+  def unbindConsumer(consumer: ObservationStateConsumer):Unit = {
     registeredConsumers -= consumer
   }
 

--- a/gds-observation-state-publisher/src/test/scala/edu/gemini/aspen/gds/observationstate/impl/GDSEventsListenerTest.scala
+++ b/gds-observation-state-publisher/src/test/scala/edu/gemini/aspen/gds/observationstate/impl/GDSEventsListenerTest.scala
@@ -5,7 +5,7 @@ import java.util
 
 import org.junit.runner.RunWith
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 import org.scalatest.mock.MockitoSugar

--- a/gds-observation-state-publisher/src/test/scala/edu/gemini/aspen/gds/observationstate/impl/InspectPolicyTest.scala
+++ b/gds-observation-state-publisher/src/test/scala/edu/gemini/aspen/gds/observationstate/impl/InspectPolicyTest.scala
@@ -11,7 +11,7 @@ import fits.FitsKeyword
 
 class InspectPolicyTest {
     @Test
-    def testMissing() {
+    def testMissing():Unit = {
         val config = mock(classOf[GDSConfigurationService])
         when(config.getConfiguration).thenReturn(GDSConfiguration("GPI", "OBS_START_ACQ", "AIRMASS", 0, "DOUBLE", true, "NONE", "EPICS", "gpi:value", 0, "", "Mean airmass for the observation") :: GDSConfiguration("GPI", "OBS_START_ACQ", "AIRMASS2", 0, "DOUBLE", true, "NONE", "EPICS", "gpi:value", 0, "", "Mean airmass for the observation") :: Nil)
         val obsState = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
@@ -22,7 +22,7 @@ class InspectPolicyTest {
     }
 
     @Test
-    def testError() {
+    def testError():Unit = {
         val config = mock(classOf[GDSConfigurationService])
         when(config.getConfiguration).thenReturn(GDSConfiguration("GPI", "OBS_START_ACQ", "AIRMASS", 0, "DOUBLE", true, "NONE", "EPICS", "gpi:value", 0, "", "Mean airmass for the observation") :: GDSConfiguration("GPI", "OBS_START_ACQ", "AIRMASS2", 0, "DOUBLE", true, "NONE", "EPICS", "gpi:value", 0, "", "Mean airmass for the observation") :: Nil)
         val obsState = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))

--- a/gds-observation-state-publisher/src/test/scala/edu/gemini/aspen/gds/observationstate/impl/ObservationStateImplTest.scala
+++ b/gds-observation-state-publisher/src/test/scala/edu/gemini/aspen/gds/observationstate/impl/ObservationStateImplTest.scala
@@ -14,7 +14,7 @@ import edu.gemini.aspen.gds.api.fits.FitsKeyword
 class ObservationStateImplTest {
 
   @Test
-  def testObsInProgress() {
+  def testObsInProgress():Unit = {
     val obsState: ObservationStateImpl = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     assertTrue(obsState.getObservationsInProgress.isEmpty)
 
@@ -29,7 +29,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testLastDataLabel() {
+  def testLastDataLabel():Unit = {
     val obsState: ObservationStateImpl = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     obsState.startObservation("label1")
     obsState.startObservation("label2")
@@ -41,7 +41,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testLastDataLabels() {
+  def testLastDataLabels():Unit = {
     val obsState: ObservationStateImpl = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     obsState.startObservation("label1")
     obsState.startObservation("label2")
@@ -57,7 +57,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testMissing() {
+  def testMissing():Unit = {
     val obsState: ObservationStateImpl = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     obsState.startObservation("label1")
     obsState.registerMissingKeyword("label1", FitsKeyword("A") :: Nil)
@@ -66,7 +66,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testError() {
+  def testError():Unit = {
     val obsState: ObservationStateImpl = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     obsState.startObservation("label1")
     obsState.registerCollectionError("label1", List((FitsKeyword("A"), CollectionError.GenericError)))
@@ -75,7 +75,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testInError() {
+  def testInError():Unit = {
     val obsState = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     assertEquals(obsState.isInError("label1"), None)
     obsState.startObservation("label1")
@@ -85,7 +85,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testFailed() {
+  def testFailed():Unit = {
     val obsState = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     assertEquals(obsState.isFailed("label1"), None)
     obsState.startObservation("label1")
@@ -97,7 +97,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testExpiration() {
+  def testExpiration():Unit = {
     val obsState: ObservationStateImpl = new ObservationStateImpl(mock(classOf[ObservationStatePublisher])) {
       override def expirationMillis = 5
     }
@@ -115,7 +115,7 @@ class ObservationStateImplTest {
   }
 
   @Test
-  def testTimestamp() {
+  def testTimestamp():Unit = {
     val obsState: ObservationStateImpl = new ObservationStateImpl(mock(classOf[ObservationStatePublisher]))
     obsState.startObservation("label1")
     obsState.registerMissingKeyword("label1", FitsKeyword("A") :: Nil)

--- a/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObsEventBookKeeping.scala
+++ b/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObsEventBookKeeping.scala
@@ -3,7 +3,7 @@ package edu.gemini.aspen.gds.obsevent.handler
 import java.util.EnumSet
 import edu.gemini.aspen.giapi.data.{DataLabel, ObservationEvent}
 import collection.mutable.{SynchronizedMap, HashMap}
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 /**
  * Keep track of which observation events have arrived and which data collection are done
@@ -43,7 +43,7 @@ class ObsEventBookKeeping {
   /**
    * Indicate that data collection for a given obs event is done
    */
-  def addReply(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  def addReply(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     val repliesSet = repliesMap.getOrElseUpdate(dataLabel, EnumSet.noneOf(classOf[ObservationEvent]))
     repliesSet.add(obsEvent)
   }
@@ -51,7 +51,7 @@ class ObsEventBookKeeping {
   /**
    * Indicate that an obs event has arrived
    */
-  def addObs(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  def addObs(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     val obsSet = obsEventsMap.getOrElseUpdate(dataLabel, EnumSet.noneOf(classOf[ObservationEvent]))
     obsSet.add(obsEvent)
   }
@@ -59,7 +59,7 @@ class ObsEventBookKeeping {
   /**
    * Delete all data for a given DataLabel
    */
-  def clean(dataLabel: DataLabel) {
+  def clean(dataLabel: DataLabel):Unit = {
     repliesMap -= dataLabel
     obsEventsMap -= dataLabel
   }

--- a/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationEvent2EventAdmin.scala
+++ b/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationEvent2EventAdmin.scala
@@ -8,7 +8,7 @@ import org.osgi.service.event.{Event, EventAdmin}
  * Very simple object that passes observation events through OSGi EventAdmin */
 class ObservationEvent2EventAdmin(publisher: EventAdmin) extends ObservationEventHandler {
 
-  def onObservationEvent(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  def onObservationEvent(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     val properties: java.util.HashMap[String, (ObservationEvent, DataLabel)] = new java.util.HashMap()
     properties.put(GDSObseventHandler.ObsEventKey, (obsEvent, dataLabel))
     val event = new Event(GDSObseventHandler.ObsEventTopic, properties)

--- a/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationEventLogger.scala
+++ b/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationEventLogger.scala
@@ -15,7 +15,7 @@ class ObservationEventLogger(val collectDeadline: Long = 5000L)(implicit LOG: Lo
 
   /**
    * Checks whether the timing for a given event and dataLabel is within constraints and writes to log */
-  def checkTimeWithinLimits(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  def checkTimeWithinLimits(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     // Function with side effects
     // check if the keyword recollection was performed on time
     if (!check(dataLabel, obsEvent, collectDeadline)) {
@@ -25,7 +25,7 @@ class ObservationEventLogger(val collectDeadline: Long = 5000L)(implicit LOG: Lo
 
   /**
    * Logs the timing of an ObservationEvent of a datalabel */
-  def logTiming(evt: ObservationEvent, label: DataLabel) {
+  def logTiming(evt: ObservationEvent, label: DataLabel):Unit = {
     val avgTime = average(evt) map {
       x => x.toMillis
     } getOrElse {
@@ -42,7 +42,7 @@ class ObservationEventLogger(val collectDeadline: Long = 5000L)(implicit LOG: Lo
 
   /**
    * Verifies that the time constraints requested for certain events are fulfilled */
-  def enforceTimeConstraints(evt: ObservationEvent, label: DataLabel) {
+  def enforceTimeConstraints(evt: ObservationEvent, label: DataLabel):Unit = {
     evt match {
       case OBS_START_ACQ => checkTimeWithinLimits(evt, label)
       case OBS_END_ACQ => checkTimeWithinLimits(evt, label)

--- a/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationTransactionsStore.scala
+++ b/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationTransactionsStore.scala
@@ -1,6 +1,6 @@
 package edu.gemini.aspen.gds.obsevent.handler
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.collection.concurrent._
 import com.google.common.cache.CacheBuilder
 import edu.gemini.aspen.giapi.data.DataLabel
@@ -16,7 +16,7 @@ class ObservationTransactionsStore {
     .expireAfterWrite(expirationMillis, TimeUnit.MILLISECONDS)
     .build[DataLabel, String]().asMap()
 
-  def startTransaction(dataLabel: DataLabel) {
+  def startTransaction(dataLabel: DataLabel):Unit = {
     observationTransactions.put(dataLabel, "")
   }
 

--- a/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ReplyHandler.scala
+++ b/gds-obsevent-handler/src/main/scala/edu/gemini/aspen/gds/obsevent/handler/ReplyHandler.scala
@@ -36,7 +36,7 @@ class ReplyHandler(actorsFactory: CompositeActorsFactory,
     publisher.postEvent(event)
   }
 
-  def act() {
+  def act():Unit = {
     loop {
       react {
         case AcquisitionRequest(obsEvent, dataLabel) => acqRequest(obsEvent, dataLabel)
@@ -46,7 +46,7 @@ class ReplyHandler(actorsFactory: CompositeActorsFactory,
     }
   }
 
-  private def acqRequest(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  private def acqRequest(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     LOG.info("ObservationEvent " + obsEvent + " for " + dataLabel)
     obsEvent match {
       case OBS_PREP =>
@@ -68,9 +68,9 @@ class ReplyHandler(actorsFactory: CompositeActorsFactory,
     new KeywordSetComposer(actorsFactory, keywordsDatabase) ! AcquisitionRequest(obsEvent, dataLabel)
   }
 
-  def writeFinalFile(dataLabel: DataLabel, obsEvent: ObservationEvent) {
+  def writeFinalFile(dataLabel: DataLabel, obsEvent: ObservationEvent):Unit = {
 
-    def retry(retries: Int, sleep: Long) {
+    def retry(retries: Int, sleep: Long):Unit = {
       Thread.sleep(sleep)
       if (bookKeeper.allRepliesArrived(dataLabel)) {
         //OK, can continue
@@ -98,7 +98,7 @@ class ReplyHandler(actorsFactory: CompositeActorsFactory,
     }
   }
 
-  private def acqRequestReply(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  private def acqRequestReply(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     //check that this obsevent collection reply hasn't already arrived but that the obsevent has.
     if (bookKeeper.replyArrived(obsEvent, dataLabel)) {
       LOG.severe("Received data collection reply for observation event " + obsEvent + " for datalabel " + dataLabel + " twice")
@@ -118,7 +118,7 @@ class ReplyHandler(actorsFactory: CompositeActorsFactory,
 
   }
 
-  private def endAcqRequestReply(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  private def endAcqRequestReply(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     eventLogger.end(dataLabel, obsEvent)
     eventLogger.enforceTimeConstraints(obsEvent, dataLabel)
 
@@ -132,7 +132,7 @@ class ReplyHandler(actorsFactory: CompositeActorsFactory,
     }
   }
 
-  private def completeFile(obsEvent: ObservationEvent, dataLabel: DataLabel) {
+  private def completeFile(obsEvent: ObservationEvent, dataLabel: DataLabel):Unit = {
     bookKeeper.clean(dataLabel)
 
     try {

--- a/gds-obsevent-handler/src/test/scala/edu/gemini/aspen/gds/obsevent/handler/FitsFileProcessorTest.scala
+++ b/gds-obsevent-handler/src/test/scala/edu/gemini/aspen/gds/obsevent/handler/FitsFileProcessorTest.scala
@@ -1,7 +1,7 @@
 package edu.gemini.aspen.gds.obsevent.handler
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import edu.gemini.aspen.giapi.data.DataLabel
 import edu.gemini.aspen.gds.api.Conversions._
 import java.io.File

--- a/gds-obsevent-handler/src/test/scala/edu/gemini/aspen/gds/obsevent/handler/GDSObseventHandlerImplTest.scala
+++ b/gds-obsevent-handler/src/test/scala/edu/gemini/aspen/gds/obsevent/handler/GDSObseventHandlerImplTest.scala
@@ -1,7 +1,7 @@
 package edu.gemini.aspen.gds.obsevent.handler
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import edu.gemini.aspen.giapi.data.{DataLabel, ObservationEvent}
 import edu.gemini.aspen.gds.keywords.database.impl.KeywordsDatabaseImpl
 import edu.gemini.aspen.gds.actors.factory.CompositeActorsFactory
@@ -171,7 +171,7 @@ class GDSObseventHandlerImplTest extends FunSuite with OneInstancePerTest with B
     new Event(GDSObseventHandler.ObsEventTopic, properties)
   }
 
-  private def sleep(time: Long) {
+  private def sleep(time: Long):Unit = {
     TimeUnit.MILLISECONDS.sleep(time)
   }
 

--- a/gds-obsevent-handler/src/test/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationEventLoggerTest.scala
+++ b/gds-obsevent-handler/src/test/scala/edu/gemini/aspen/gds/obsevent/handler/ObservationEventLoggerTest.scala
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.Assert._
 import org.scalatest.junit.JUnitRunner
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import java.util.logging.Logger
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{OneInstancePerTest, FunSuite}
@@ -41,7 +41,7 @@ class ObservationEventLoggerTest extends FunSuite with MockitoSugar {
 
     logger.checkTimeWithinLimits(OBS_PREP, dataLabel)
 
-    verifyZeroInteractions(LOG)
+    verifyNoInteractions(LOG)
   }
 
   test("log timing") {

--- a/gds-performance-monitoring/src/main/scala/edu/gemini/aspen/gds/performancemonitoring/EventLogger.scala
+++ b/gds-performance-monitoring/src/main/scala/edu/gemini/aspen/gds/performancemonitoring/EventLogger.scala
@@ -16,15 +16,15 @@ class EventLogger[A, B] {
   //map: eventSet -> (event -> (startTime, endTime))
   private val map = new mutable.HashMap[A, collection.mutable.Map[B, (Option[LocalDateTime], Option[LocalDateTime])]] with mutable.SynchronizedMap[A, collection.mutable.Map[B, (Option[LocalDateTime], Option[LocalDateTime])]]
 
-  def addEventSet(set: A) {
+  def addEventSet(set: A):Unit = {
     map += set -> new mutable.HashMap[B, (Option[LocalDateTime], Option[LocalDateTime])] with mutable.SynchronizedMap[B, (Option[LocalDateTime], Option[LocalDateTime])]
   }
 
-  def start(set: A, evt: B) {
+  def start(set: A, evt: B):Unit = {
     map.getOrElseUpdate(set, new mutable.HashMap[B, (Option[LocalDateTime], Option[LocalDateTime])] with mutable.SynchronizedMap[B, (Option[LocalDateTime], Option[LocalDateTime])]) += evt ->(Some(LocalDateTime.now), map(set).getOrElse(evt, (None, None))._2)
   }
 
-  def end(set: A, evt: B) {
+  def end(set: A, evt: B):Unit = {
     map.getOrElseUpdate(set, new mutable.HashMap[B, (Option[LocalDateTime], Option[LocalDateTime])] with mutable.SynchronizedMap[B, (Option[LocalDateTime], Option[LocalDateTime])]) += evt ->(map(set).getOrElse(evt, (None, None))._1, Some(LocalDateTime.now))
   }
 

--- a/gds-performance-monitoring/src/test/scala/edu/gemini/aspen/gds/performancemonitoring/EventLoggerTest.scala
+++ b/gds-performance-monitoring/src/test/scala/edu/gemini/aspen/gds/performancemonitoring/EventLoggerTest.scala
@@ -24,7 +24,7 @@ class EventLoggerTest extends AssertionsForJUnit {
   var holaInterval: Duration = _
 
   @Before
-  def setup() {
+  def setup():Unit = {
     el = new EventLogger
 
     el.addEventSet("set")
@@ -49,7 +49,7 @@ class EventLoggerTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testRetrieve() {
+  def testRetrieve():Unit = {
 
     val x = el.retrieve("set")
     assert(check(x("hola").get, holaInterval, precision), "Time is: " + x("hola").get)
@@ -58,7 +58,7 @@ class EventLoggerTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testRetrieveEvent() {
+  def testRetrieveEvent():Unit = {
     el.retrieve("set", "hola") match {
       case Some(x: Duration) => assert(check(x, holaInterval, precision), "Time is: " + x)
       case _ => fail()
@@ -66,7 +66,7 @@ class EventLoggerTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testRetrieveEventEmpty() {
+  def testRetrieveEventEmpty():Unit = {
     el.retrieve("set", "chao") match {
       case None =>
       case _ => fail()
@@ -74,7 +74,7 @@ class EventLoggerTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testRetrieveEventAverage() {
+  def testRetrieveEventAverage():Unit = {
     el.average("hola") match {
       case Some(x: Duration) => assert(check(x, delay, precision), "Time is: " + x)
       case _ => fail()
@@ -82,7 +82,7 @@ class EventLoggerTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testRetrieveEventAverageEmpty() {
+  def testRetrieveEventAverageEmpty():Unit = {
     el.average("chao") match {
       case None =>
       case _ => fail()
@@ -90,12 +90,12 @@ class EventLoggerTest extends AssertionsForJUnit {
   }
 
   @Test
-  def testCheck() {
+  def testCheck():Unit = {
     assert(el.check("set", "hola", 600))
   }
 
   @Test
-  def testCheckEmpty() {
+  def testCheckEmpty():Unit = {
     assert(!el.check("set", "chao", 600))
   }
 

--- a/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/DeleteOriginalPolicy.scala
+++ b/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/DeleteOriginalPolicy.scala
@@ -13,7 +13,7 @@ class DeleteOriginalPolicy extends DefaultPostProcessingPolicy {
 
   override def toString = this.getClass.getSimpleName
 
-  override def fileReady(originalFile: File, processedFile: File) {
+  override def fileReady(originalFile: File, processedFile: File):Unit = {
     LOG.info(s"Delete original file $originalFile")
     if (!originalFile.delete()) {
       LOG.warning(s"Could not delete original file $originalFile")

--- a/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/SetOwnershipPolicy.scala
+++ b/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/SetOwnershipPolicy.scala
@@ -15,12 +15,12 @@ class SetOwnershipPolicy(owner: String, sudo: String) extends DefaultPostProcess
 
   override val priority = 13
 
-  override def fileReady(originalFile: File, processedFile: File) {
+  override def fileReady(originalFile: File, processedFile: File):Unit = {
     LOG.info(s"Set file $processedFile ownership to $owner")
 
     val cmd = s"${if (useSudo) "sudo " else ""}chown $owner $processedFile"
     LOG.info(cmd)
-    
+
     val result = cmd.!
     if (result != 0) {
       LOG.severe(s"Failed command $cmd")

--- a/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/SetPermissionsPolicy.scala
+++ b/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/SetPermissionsPolicy.scala
@@ -15,7 +15,7 @@ class SetPermissionsPolicy(permissions: String, sudo: String) extends DefaultPos
 
   override val priority = 12
 
-  override def fileReady(originalFile: File, processedFile: File) {
+  override def fileReady(originalFile: File, processedFile: File):Unit = {
     LOG.info(s"Set file $processedFile permissions to $permissions")
 
     val cmd = s"${if (useSudo) "sudo " else ""}chmod $permissions $processedFile"

--- a/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/osgi/SetOwnershipPolicyFactory.scala
+++ b/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/osgi/SetOwnershipPolicyFactory.scala
@@ -37,7 +37,7 @@ class SetOwnershipPolicyFactory(context: BundleContext) extends ManagedServiceFa
   }
 
   def stopServices(): Unit = {
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     for (pid <- existingServices.keySet) {
       deleted(pid)
     }

--- a/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/osgi/SetPermissionsPolicyFactory.scala
+++ b/gds-postprocessing-policy/src/main/scala/edu/gemini/aspen/gds/postprocessingpolicy/osgi/SetPermissionsPolicyFactory.scala
@@ -37,7 +37,7 @@ class SetPermissionsPolicyFactory(context: BundleContext) extends ManagedService
   }
 
   def stopServices(): Unit = {
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     for (pid <- existingServices.keySet) {
       deleted(pid)
     }

--- a/gds-postprocessing-policy/src/test/scala/edu/gemini/aspen/gds/postprocessingpolicy/DeleteOriginalPolicyTest.scala
+++ b/gds-postprocessing-policy/src/test/scala/edu/gemini/aspen/gds/postprocessingpolicy/DeleteOriginalPolicyTest.scala
@@ -6,7 +6,7 @@ import com.google.common.io.Files
 
 class DeleteOriginalPolicyTest {
   @Test
-  def testNonErrors() {
+  def testNonErrors():Unit = {
     val file1 = Files.createTempDir()
     val deleteOriginal = new DeleteOriginalPolicy()
     deleteOriginal.fileReady(file1, file1)

--- a/gds-postprocessing-policy/src/test/scala/edu/gemini/aspen/gds/postprocessingpolicy/ErrorsRemovedPolicyTest.scala
+++ b/gds-postprocessing-policy/src/test/scala/edu/gemini/aspen/gds/postprocessingpolicy/ErrorsRemovedPolicyTest.scala
@@ -10,7 +10,7 @@ class ErrorsRemovedPolicyTest {
     val dataLabel = new DataLabel("some key")
 
     @Test
-    def testNonErrors() {
+    def testNonErrors():Unit = {
         val ep = new ErrorsRemovedPolicy()
         val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: Nil
 
@@ -18,7 +18,7 @@ class ErrorsRemovedPolicyTest {
     }
 
     @Test
-    def testWithOneError() {
+    def testWithOneError():Unit = {
         val ep = new ErrorsRemovedPolicy()
         val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: ErrorCollectedValue("KEY2", CollectionError.GenericError, "comment", 0) :: Nil
         val filteredValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: Nil
@@ -27,7 +27,7 @@ class ErrorsRemovedPolicyTest {
     }
 
     @Test
-    def testCompositeErrorRemoved() {
+    def testCompositeErrorRemoved():Unit = {
         val ep = new CompositePostProcessingPolicyImpl()
         val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: ErrorCollectedValue("KEY2", CollectionError.GenericError, "comment", 0) :: Nil
         val filteredValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: Nil
@@ -37,7 +37,7 @@ class ErrorsRemovedPolicyTest {
     }
 
     @Test
-    def testCompositeDefaultErrorRemoved() {
+    def testCompositeDefaultErrorRemoved():Unit = {
         val ep = new CompositePostProcessingPolicyImpl()
         val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: ErrorCollectedValue("KEY2", CollectionError.GenericError, "comment", 0) :: Nil
         val filteredValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: Nil
@@ -49,7 +49,7 @@ class ErrorsRemovedPolicyTest {
     }
 
     @Test
-    def testCompositeErrorRemovedDefault() {
+    def testCompositeErrorRemovedDefault():Unit = {
         val ep = new CompositePostProcessingPolicyImpl()
         val collectedValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: ErrorCollectedValue("KEY2", CollectionError.GenericError, "comment", 0) :: Nil
         val filteredValues = CollectedValue[Double]("KEY1", 1.0, "comment", 0, None) :: Nil

--- a/gds-seqexec-actors/src/test/scala/edu/gemini/aspen/gds/seqexec/SeqexecActorsTest.scala
+++ b/gds-seqexec-actors/src/test/scala/edu/gemini/aspen/gds/seqexec/SeqexecActorsTest.scala
@@ -15,7 +15,7 @@ class SeqexecActorsTest {
    * Test for the common case of a value found in the local DB
    */
   @Test
-  def testActor() {
+  def testActor():Unit = {
     db ! Store("labelint", "KEY", 1.asInstanceOf[AnyRef])
     db ! Store("labelstring", "KEY", "1".asInstanceOf[AnyRef])
     db ! Store("labeldouble", "KEY", 1.0.asInstanceOf[AnyRef])
@@ -31,7 +31,7 @@ class SeqexecActorsTest {
   }
 
   @Test
-  def testWrongType() {
+  def testWrongType():Unit = {
     val db = new TemporarySeqexecKeywordsDatabaseImpl
     db ! Store("label", "KEY", "1.1")
 
@@ -40,7 +40,7 @@ class SeqexecActorsTest {
   }
 
   @Test
-  def testActorInt() {
+  def testActorInt():Unit = {
     db ! Store("label", "KEY", 1.asInstanceOf[AnyRef])
 
     val seqActor = new SeqexecActor(db, "label", GDSConfiguration("GPI", "OBS_START_ACQ", "KEY", 0, "INT", true, "null", "SEQEXEC", "KEY", 0, "", "my comment") :: Nil)
@@ -52,7 +52,7 @@ class SeqexecActorsTest {
    * Test for a non mandatory value not found in the local DB
    */
   @Test
-  def testNotMandatoryNotFoundValue() {
+  def testNotMandatoryNotFoundValue():Unit = {
     val seqActor = new SeqexecActor(db, "label", GDSConfiguration("GPI", "OBS_START_ACQ", "KEY", 0, "INT", false, "DEFAULT", "SEQEXEC", "KEY", 0, "", "my comment") :: Nil)
 
     // should not return anything if the value cannot be read. The default will be added by an PostProcessingPolicy
@@ -64,7 +64,7 @@ class SeqexecActorsTest {
    * Test for a mandatory value not found in the local DB
    */
   @Test
-  def testMandatoryNotFoundValue() {
+  def testMandatoryNotFoundValue():Unit = {
     val seqActor = new SeqexecActor(db, "label", GDSConfiguration("GPI", "OBS_START_ACQ", "KEY", 0, "INT", true, "DEFAULT", "SEQEXEC", "KEY", 0, "", "my comment") :: Nil)
 
     // should not return anything if the value cannot be read. The default will be added by an PostProcessingPolicy
@@ -73,7 +73,7 @@ class SeqexecActorsTest {
   }
 
   @Test
-  def testActorFactory() {
+  def testActorFactory():Unit = {
     db ! Store("label", "TEST", (1.0).asInstanceOf[AnyRef])
 
     val factory = new SeqexecActorsFactory(db)

--- a/gds-static-header-receiver/src/main/scala/edu/gemini/aspen/gds/staticheaderreceiver/SeqexecHeaderServlet.scala
+++ b/gds-static-header-receiver/src/main/scala/edu/gemini/aspen/gds/staticheaderreceiver/SeqexecHeaderServlet.scala
@@ -8,7 +8,7 @@ import org.apache.xmlrpc.webserver.XmlRpcServlet
 import org.ops4j.pax.web.service.WebContainer
 import org.osgi.service.event.EventAdmin
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.collection._
 
 trait HeaderReceiver

--- a/gds-static-header-receiver/src/main/scala/edu/gemini/aspen/gds/staticheaderreceiver/TemporarySeqexecKeywordsDatabase.scala
+++ b/gds-static-header-receiver/src/main/scala/edu/gemini/aspen/gds/staticheaderreceiver/TemporarySeqexecKeywordsDatabase.scala
@@ -8,7 +8,7 @@ import edu.gemini.aspen.gds.staticheaderreceiver.TemporarySeqexecKeywordsDatabas
 import edu.gemini.aspen.giapi.data.DataLabel
 
 import scala.actors.Actor
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.collection.concurrent._
 
 /**
@@ -46,7 +46,7 @@ class TemporarySeqexecKeywordsDatabaseImpl extends TemporarySeqexecKeywordsDatab
 
   start()
 
-  def act() {
+  def act():Unit = {
     loop {
       react {
         case Store(dataLabel, key, value) => store(dataLabel, key, value)
@@ -63,11 +63,11 @@ class TemporarySeqexecKeywordsDatabaseImpl extends TemporarySeqexecKeywordsDatab
     .expireAfterWrite(expirationMillis, MILLISECONDS)
     .build[DataLabel, ValuesCollection]().asMap()
 
-  private def cleanAll() {
+  private def cleanAll():Unit = {
     map.clear()
   }
 
-  private def clean(dataLabel: DataLabel) {
+  private def clean(dataLabel: DataLabel):Unit = {
     map -= dataLabel
   }
 
@@ -84,7 +84,7 @@ class TemporarySeqexecKeywordsDatabaseImpl extends TemporarySeqexecKeywordsDatab
   }
 
 
-  private def store(dataLabel: DataLabel, keyword: FitsKeyword, value: AnyRef) {
+  private def store(dataLabel: DataLabel, keyword: FitsKeyword, value: AnyRef):Unit = {
     if (!map.contains(dataLabel)) {
       map += (dataLabel -> collection.mutable.Map.empty[FitsKeyword, AnyRef])
     }

--- a/gds-static-header-receiver/src/main/scala/edu/gemini/aspen/gds/staticheaderreceiver/XmlRpcReceiver.scala
+++ b/gds-static-header-receiver/src/main/scala/edu/gemini/aspen/gds/staticheaderreceiver/XmlRpcReceiver.scala
@@ -25,7 +25,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param programId The ID of the program in the ODB that specifies this observation
    * @param dataLabel The name of the FITS file to be written
    */
-  def openObservation(programId: String, dataLabel: String) {
+  def openObservation(programId: String, dataLabel: String):Unit = {
     LOG.info(s"Opened Observation, Program ID: $programId Data label: $dataLabel")
     programIdDB ! StoreProgramId(dataLabel, programId)
     sendData(ObservationEvent.EXT_START_OBS, new DataLabel(dataLabel))
@@ -38,7 +38,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param dataLabel The name of the FITS file to be written, and to which keywords must be associated
    * @param keywords An array of Strings, each of which contains three parts, separated by a comma: the keyword name, the data type and the value
    */
-  def openObservation(programId: String, dataLabel: String, keywords: Array[Object]) {
+  def openObservation(programId: String, dataLabel: String, keywords: Array[Object]):Unit = {
     openObservation(programId, dataLabel)
     storeKeywords(dataLabel, keywords)
   }
@@ -48,7 +48,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    *
    * @param dataLabel The name of the FITS file to be written
    */
-  def closeObservation(dataLabel: String) {
+  def closeObservation(dataLabel: String):Unit = {
     LOG.info(s"Closed Observation, Data label: $dataLabel")
     sendData(ObservationEvent.EXT_END_OBS, new DataLabel(dataLabel))
   }
@@ -59,7 +59,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param dataLabel The name of the FITS file to be written, and to which keywords must be associated
    * @param keywords An array of Strings, each of which contains three parts, separated by a comma: the keyword name, the data type and the value
    */
-  def closeObservation(dataLabel: String, keywords: Array[Object]) {
+  def closeObservation(dataLabel: String, keywords: Array[Object]):Unit = {
     storeKeywords(dataLabel, keywords)
     closeObservation(dataLabel)
   }
@@ -71,7 +71,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param keyword The FITS keyword name
    * @param value The FITS keyword value
    */
-  def storeKeyword(dataLabel: String, keyword: String, value: String) {
+  def storeKeyword(dataLabel: String, keyword: String, value: String):Unit = {
     LOG.info(s"Data label: $dataLabel Keyword: $keyword Value: $value")
     keywordsDatabase ! Store(dataLabel, keyword, value)
   }
@@ -83,7 +83,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param keyword The FITS keyword name
    * @param value The FITS keyword value
    */
-  def storeKeyword(dataLabel: String, keyword: String, value: Double) {
+  def storeKeyword(dataLabel: String, keyword: String, value: Double):Unit = {
     LOG.info(s"Data label: $dataLabel Keyword: $keyword Value: $value")
     keywordsDatabase ! Store(dataLabel, keyword, value.asInstanceOf[AnyRef])
   }
@@ -95,7 +95,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param keyword The FITS keyword name
    * @param value The FITS keyword value
    */
-  def storeKeyword(dataLabel: String, keyword: String, value: Int) {
+  def storeKeyword(dataLabel: String, keyword: String, value: Int):Unit = {
     LOG.info(s"Data label: $dataLabel Keyword: $keyword Value: $value")
     keywordsDatabase ! Store(dataLabel, keyword, value.asInstanceOf[AnyRef])
   }
@@ -107,7 +107,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param keyword The FITS keyword name
    * @param value The FITS keyword value
    */
-  def storeKeyword(dataLabel: String, keyword: String, value: Boolean) {
+  def storeKeyword(dataLabel: String, keyword: String, value: Boolean):Unit = {
     LOG.info(s"Data label: $dataLabel Keyword: $keyword Value: $value")
     keywordsDatabase ! Store(dataLabel, keyword, value.asInstanceOf[AnyRef])
   }
@@ -118,7 +118,7 @@ class XmlRpcReceiver(keywordsDatabase: TemporarySeqexecKeywordsDatabase, program
    * @param dataLabel The name of the FITS file to be written, and to which keywords must be associated
    * @param keywords An array of Strings, each of which contains three parts, separated by a comma: the keyword name, the data type and the value
    */
-  def storeKeywords(dataLabel: String, keywords: Array[Object]) {
+  def storeKeywords(dataLabel: String, keywords: Array[Object]):Unit = {
     val regex = """(\w*),(\w*),(.*)""".r
     for {
       keyword <- keywords

--- a/gds-static-header-receiver/src/test/scala/edu/gemini/aspen/gds/staticheaderreceiver/TemporarySeqexecKeywordsDatabaseImplTest.scala
+++ b/gds-static-header-receiver/src/test/scala/edu/gemini/aspen/gds/staticheaderreceiver/TemporarySeqexecKeywordsDatabaseImplTest.scala
@@ -13,7 +13,7 @@ class TemporarySeqexecKeywordsDatabaseImplTest {
   val originalValue = "VAL"
 
   @Test
-  def testStoreAndRetrieve() {
+  def testStoreAndRetrieve():Unit = {
     // Verify we can store and retrieve
     val db = new TemporarySeqexecKeywordsDatabaseImpl
     db ! Store(dataLabel, keyword, originalValue)
@@ -33,7 +33,7 @@ class TemporarySeqexecKeywordsDatabaseImplTest {
   }
 
   @Test
-  def testStoreAndRetrieveUnknown() {
+  def testStoreAndRetrieveUnknown():Unit = {
     // Verify we can store and retrieve
     val db = new TemporarySeqexecKeywordsDatabaseImpl
     db ! Store(dataLabel, keyword, originalValue)
@@ -46,7 +46,7 @@ class TemporarySeqexecKeywordsDatabaseImplTest {
   }
 
   @Test
-  def testStoreAndRetrieveAll() {
+  def testStoreAndRetrieveAll():Unit = {
     val db = new TemporarySeqexecKeywordsDatabaseImpl
     db ! Store(dataLabel, keyword, originalValue)
 
@@ -60,7 +60,7 @@ class TemporarySeqexecKeywordsDatabaseImplTest {
   }
 
   @Test
-  def testExpiration() {
+  def testExpiration():Unit = {
     val db = new TemporarySeqexecKeywordsDatabaseImpl {
       override def expirationMillis = 1
     }

--- a/gds-static-header-receiver/src/test/scala/edu/gemini/aspen/gds/staticheaderreceiver/XmlRpcReceiverTest.scala
+++ b/gds-static-header-receiver/src/test/scala/edu/gemini/aspen/gds/staticheaderreceiver/XmlRpcReceiverTest.scala
@@ -19,7 +19,7 @@ class XmlRpcReceiverTest extends AssertionsForJUnit with MockitoSugar {
 
 
   @Test
-  def testDB() {
+  def testDB():Unit = {
     db ! Store("label", "KEY", 1.asInstanceOf[AnyRef])
     db !?(1000, Retrieve("label", "KEY")) match {
       case Some(Some(1)) =>
@@ -42,7 +42,7 @@ class XmlRpcReceiverTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   @Test
-  def testXmlRpcReceiver() {
+  def testXmlRpcReceiver():Unit = {
     xmlRpcReceiver.openObservation("id", "label")
     xmlRpcReceiver.storeKeyword("label", "KEY", 1)
     xmlRpcReceiver.storeKeywords("label2", ("KEY,INT,1" :: "KEY2,DOUBLE,1.0" :: "KEY3,STRING,uno" :: Nil).toArray)

--- a/giapi-clients-lib/src/main/scala/edu/gemini/giapi/clients/lib/sshexec/package.scala
+++ b/giapi-clients-lib/src/main/scala/edu/gemini/giapi/clients/lib/sshexec/package.scala
@@ -14,8 +14,8 @@ import scala.util.{Failure, Success}
 package object sshexec {
 
   trait MessageListener {
-    def newLine(line: String)
-    def newErrorLine(line: String)
+    def newLine(line: String): Unit
+    def newErrorLine(line: String): Unit
   }
 
   def sshexec(command: String, listener: MessageListener, username: String, host: String, key: InputStream, knownHosts: InputStream): CommandOperationResult = {

--- a/giapi-clients-lib/src/main/scala/edu/gemini/giapi/clients/lib/status/ItemsStateProvider.scala
+++ b/giapi-clients-lib/src/main/scala/edu/gemini/giapi/clients/lib/status/ItemsStateProvider.scala
@@ -4,7 +4,7 @@ import edu.gemini.aspen.giapi.status.StatusItem
 import edu.gemini.aspen.giapi.util.jms.status.StatusGetter
 import edu.gemini.jms.api.JmsProvider
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 

--- a/giapi-clients-lib/src/test/scala/edu/gemini/giapi/clients/lib/commands/CommandsTest.scala
+++ b/giapi-clients-lib/src/test/scala/edu/gemini/giapi/clients/lib/commands/CommandsTest.scala
@@ -4,19 +4,19 @@ import edu.gemini.aspen.giapi.commands._
 import edu.gemini.aspen.gmp.commands.jms.client.CommandSenderClient
 import org.junit.runner.RunWith
 import org.junit.Assert._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.junit.JUnitRunner
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 @RunWith(classOf[JUnitRunner])
-class CommandsTest extends FunSuite with MockitoSugar with ScalaFutures {
+class CommandsTest extends AnyFunSuite with MockitoSugar with ScalaFutures {
   test("no reply") {
     val sender = mock[CommandSenderClient]
     val command = new Command(SequenceCommand.TEST, Activity.PRESET)
-    when(sender.sendCommand(anyObject(), anyObject(), anyInt())).thenReturn(HandlerResponse.NOANSWER)
+    when(sender.sendCommand(any(classOf[Command]), any(classOf[CompletionListener]), anyLong())).thenReturn(HandlerResponse.NOANSWER)
 
     val r = operationResult(sender, command, None)
 

--- a/giapi-jms-util/src/test/java/edu/gemini/aspen/giapi/util/jms/status/StatusGetterTest.java
+++ b/giapi-jms-util/src/test/java/edu/gemini/aspen/giapi/util/jms/status/StatusGetterTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import javax.jms.*;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.*;
 
 public class StatusGetterTest {
@@ -22,10 +23,17 @@ public class StatusGetterTest {
         Session session = mock(Session.class);
         when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
 
+        Queue queue = mock(Queue.class);
+        when(session.createQueue(anyString())).thenReturn(queue);
+        TemporaryQueue tempQueue = mock(TemporaryQueue.class);
+        when(session.createTemporaryQueue()).thenReturn(tempQueue);
+        Topic topic = mock(Topic.class);
+        when(session.createTopic(anyString())).thenReturn(topic);
+
         Message message = mock(Message.class);
         when(session.createMessage()).thenReturn(message);
         MessageProducer producer = mock(MessageProducer.class);
-        when(session.createProducer(any(Destination.class))).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
         MessageConsumer consumer = mock(MessageConsumer.class);
         when(session.createConsumer(any(Destination.class))).thenReturn(consumer);
 

--- a/giapi-status-service/src/test/java/edu/gemini/aspen/giapi/statusservice/StatusHandlerAggregateTest.java
+++ b/giapi-status-service/src/test/java/edu/gemini/aspen/giapi/statusservice/StatusHandlerAggregateTest.java
@@ -7,9 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.*;
 
 /**
  * Simple tests for the class StatusHandlerAggregate
@@ -51,9 +49,11 @@ public class StatusHandlerAggregateTest {
         manager.bindStatusHandler(handler);
         verifyStatusPassedAlong(handler, item);
 
+        reset(handler);
         manager.unbindStatusHandler(handler);
         verifyNoInteraction(handler, item);
     }
+
 
     private <T> void verifyStatusPassedAlong(StatusHandler handler, StatusItem<T> item) {
         // Now pass the handler and verify interaction
@@ -64,6 +64,6 @@ public class StatusHandlerAggregateTest {
     private <T> void verifyNoInteraction(StatusHandler handler, StatusItem<T> item) {
         // Verify that a call doesn't apply to handler yet
         manager.update(item);
-        verifyZeroInteractions(handler);
+        verifyNoInteractions(handler);
     }
 }

--- a/giapi-status-service/src/test/java/edu/gemini/aspen/giapi/statusservice/StatusServiceTest.java
+++ b/giapi-status-service/src/test/java/edu/gemini/aspen/giapi/statusservice/StatusServiceTest.java
@@ -10,8 +10,8 @@ import javax.jms.JMSException;
 import javax.jms.Session;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 /**
@@ -63,7 +63,6 @@ public class StatusServiceTest {
         service.stopJms();
 
         verify(provider).getConnectionFactory();
-        verifyZeroInteractions(provider);
     }
 
 }

--- a/giapi-status-service/src/test/java/edu/gemini/aspen/giapi/statusservice/jms/JmsStatusListenerTest.java
+++ b/giapi-status-service/src/test/java/edu/gemini/aspen/giapi/statusservice/jms/JmsStatusListenerTest.java
@@ -8,7 +8,7 @@ import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.Message;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**

--- a/giapi-tester/src/test/java/edu/gemini/giapi/tool/commands/CommandOperationTest.java
+++ b/giapi-tester/src/test/java/edu/gemini/giapi/tool/commands/CommandOperationTest.java
@@ -7,11 +7,11 @@ import edu.gemini.giapi.tool.arguments.ConfigArgument;
 import edu.gemini.giapi.tool.arguments.SequenceCommandArgument;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
 
 public class CommandOperationTest {
     @Test
@@ -64,7 +64,7 @@ public class CommandOperationTest {
 
         buildApplyCommand(commandOperation);
 
-        when(senderClient.sendCommand(Matchers.<Command>anyObject(), Matchers.<CompletionListener>anyObject())).thenReturn(HandlerResponse.createError("Error"));
+        when(senderClient.sendCommand(any(Command.class), any(CompletionListener.class))).thenReturn(HandlerResponse.createError("Error"));
 
         assertEquals(1, commandOperation.execute());
     }
@@ -92,7 +92,7 @@ public class CommandOperationTest {
         commandOperation.setArgument(secondConfigArgument);
 
         ArgumentCaptor<Command> argument = ArgumentCaptor.forClass(Command.class);
-        when(senderClient.sendCommand(argument.capture(), Matchers.<CompletionListener>anyObject())).thenReturn(HandlerResponse.createError("Error"));
+        when(senderClient.sendCommand(argument.capture(), any(CompletionListener.class))).thenReturn(HandlerResponse.createError("Error"));
 
         assertEquals(1, commandOperation.execute());
 
@@ -108,7 +108,7 @@ public class CommandOperationTest {
 
         buildApplyCommand(commandOperation);
 
-        when(senderClient.sendCommand(Matchers.<Command>anyObject(), Matchers.<CompletionListener>anyObject())).thenReturn(HandlerResponse.get(HandlerResponse.Response.NOANSWER));
+        when(senderClient.sendCommand(any(Command.class), any(CompletionListener.class))).thenReturn(HandlerResponse.get(HandlerResponse.Response.NOANSWER));
 
         assertEquals(1, commandOperation.execute());
     }

--- a/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/MockedJmsArtifactsTestBase.java
+++ b/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/MockedJmsArtifactsTestBase.java
@@ -1,7 +1,6 @@
 package edu.gemini.aspen.gmp.commands.jms;
 
 import edu.gemini.jms.api.JmsProvider;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import javax.jms.Connection;
@@ -15,7 +14,8 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -55,9 +55,9 @@ public class MockedJmsArtifactsTestBase {
         session = mockSessionCreation();
 
         producer = Mockito.mock(MessageProducer.class);
-        when(session.createProducer(Matchers.<Destination>anyObject())).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
         consumer = Mockito.mock(MessageConsumer.class);
-        when(session.createConsumer(Matchers.<Destination>anyObject())).thenReturn(consumer);
+        when(session.createConsumer(any(Destination.class))).thenReturn(consumer);
 
         Queue queue = mock(Queue.class);
         when(session.createQueue(anyString())).thenReturn(queue);
@@ -66,6 +66,8 @@ public class MockedJmsArtifactsTestBase {
         when(session.createTopic(anyString())).thenReturn(topic);
 
         mapMessage = Mockito.mock(MapMessage.class);
+        Destination destination = Mockito.mock(Destination.class);
+        when(mapMessage.getJMSReplyTo()).thenReturn(destination);
         when(session.createMapMessage()).thenReturn(mapMessage);
     }
 
@@ -79,7 +81,7 @@ public class MockedJmsArtifactsTestBase {
         when(connectionFactory.createConnection()).thenReturn(connection);
 
         // Mock session
-        when(connection.createSession(Matchers.anyBoolean(), Matchers.anyInt())).thenReturn(session);
+        when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
         return session;
     }
 }

--- a/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/clientbridge/CommandMessagesBridgeImplTest.java
+++ b/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/clientbridge/CommandMessagesBridgeImplTest.java
@@ -12,18 +12,16 @@ import edu.gemini.aspen.gmp.commands.jms.MockedJmsArtifactsTestBase;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
 
-import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
-import javax.jms.Topic;
+import javax.jms.Queue;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
 
 public class CommandMessagesBridgeImplTest extends MockedJmsArtifactsTestBase {
     protected CommandSender commandsSender;
@@ -61,7 +59,7 @@ public class CommandMessagesBridgeImplTest extends MockedJmsArtifactsTestBase {
     }
 
     private void verifyReplyToClientSent(int times) throws JMSException {
-        verify(producer, times(times)).send(Matchers.<Topic>anyObject(), Matchers.<MapMessage>anyObject());
+        verify(producer, times(times)).send(any(Queue.class), any(MapMessage.class));
     }
 
     /**

--- a/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/clientbridge/JmsForwardingCompletionListenerTest.java
+++ b/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/clientbridge/JmsForwardingCompletionListenerTest.java
@@ -10,17 +10,17 @@ import edu.gemini.jms.api.DestinationData;
 import edu.gemini.jms.api.DestinationType;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
+import static org.mockito.ArgumentMatchers.*;
 
 import static edu.gemini.aspen.giapi.commands.ConfigPath.configPath;
 import static edu.gemini.aspen.giapi.commands.DefaultConfiguration.configurationBuilder;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -50,7 +50,7 @@ public class JmsForwardingCompletionListenerTest extends MockedJmsArtifactsTestB
         Command referenceCommand = new Command(SequenceCommand.APPLY, Activity.PRESET, referenceConfiguration);
         completionListener.onHandlerResponse(HandlerResponse.ACCEPTED, referenceCommand);
 
-        verify(producer).send(Matchers.<Destination>anyObject(), any(MapMessage.class));
+        verify(producer).send(any(Destination.class), any(MapMessage.class));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class JmsForwardingCompletionListenerTest extends MockedJmsArtifactsTestB
         Command referenceCommand = new Command(SequenceCommand.APPLY, Activity.PRESET, referenceConfiguration);
         completionListener.onHandlerResponse(HandlerResponse.createError("Error Message"), referenceCommand);
 
-       verify(producer).send(Matchers.<Destination>anyObject(), any(MapMessage.class));
+       verify(producer).send(any(Destination.class), any(MapMessage.class));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class JmsForwardingCompletionListenerTest extends MockedJmsArtifactsTestB
         HandlerResponse response = HandlerResponse.get(HandlerResponse.Response.COMPLETED);
         completionListener.sendInitialResponseToClient(response);
 
-        verify(producer).send(Matchers.<Destination>anyObject(), any(MapMessage.class));
+        verify(producer).send(any(Destination.class), any(MapMessage.class));
         // Verify that 1 string has been set in the reply message
         verify(mapMessage, times(1)).setString(anyString(), anyString());
 
@@ -102,7 +102,7 @@ public class JmsForwardingCompletionListenerTest extends MockedJmsArtifactsTestB
         HandlerResponse response = HandlerResponse.createError("Error Message");
         completionListener.sendInitialResponseToClient(response);
 
-        verify(producer).send(Matchers.<Destination>anyObject(), any(MapMessage.class));
+        verify(producer).send(any(Destination.class), any(MapMessage.class));
         // Verify that 2 strings has been set in the reply message, including response and error message
         verify(mapMessage, times(2)).setString(anyString(), anyString());
 

--- a/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/instrumentbridge/CompletionInfoListenerTest.java
+++ b/gmp-commands-jms-bridge/src/test/java/edu/gemini/aspen/gmp/commands/jms/instrumentbridge/CompletionInfoListenerTest.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class CompletionInfoListenerTest extends MockedJmsArtifactsTestBase {
@@ -62,7 +62,7 @@ public class CompletionInfoListenerTest extends MockedJmsArtifactsTestBase {
 
         listener.onMessage(message);
 
-        verifyZeroInteractions(commandUpdater);
+        verifyNoInteractions(commandUpdater);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class CompletionInfoListenerTest extends MockedJmsArtifactsTestBase {
 
         listener.onMessage(message);
 
-        verifyZeroInteractions(commandUpdater);
+        verifyNoInteractions(commandUpdater);
     }
 
     @Test

--- a/gmp-commands-jms-client/src/test/java/edu/gemini/aspen/gmp/commands/jms/client/MockedJMSArtifactsBase.java
+++ b/gmp-commands-jms-client/src/test/java/edu/gemini/aspen/gmp/commands/jms/client/MockedJMSArtifactsBase.java
@@ -2,7 +2,6 @@ package edu.gemini.aspen.gmp.commands.jms.client;
 
 import edu.gemini.aspen.giapi.util.jms.test.MapMessageMock;
 import edu.gemini.jms.api.JmsProvider;
-import org.mockito.Matchers;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -15,7 +14,8 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
 
-import static org.mockito.Matchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,15 +37,15 @@ public class MockedJMSArtifactsBase {
         session = mockSessionCreation();
 
         producer = mock(MessageProducer.class);
-        when(session.createProducer(Matchers.<Destination>anyObject())).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
         consumer = mock(MessageConsumer.class);
-        when(session.createConsumer(Matchers.<Destination>anyObject(), Matchers.anyString())).thenReturn(consumer);
+        when(session.createConsumer(any(Destination.class), anyString())).thenReturn(consumer);
 
         Queue queue = mock(Queue.class);
-        when(session.createQueue(Matchers.anyString())).thenReturn(queue);
+        when(session.createQueue(anyString())).thenReturn(queue);
 
         Topic topic = mock(Topic.class);
-        when(session.createTopic(Matchers.anyString())).thenReturn(topic);
+        when(session.createTopic(anyString())).thenReturn(topic);
 
         mapMessage = new MapMessageMock();
         when(session.createMapMessage()).thenReturn(mapMessage);
@@ -61,7 +61,7 @@ public class MockedJMSArtifactsBase {
         when(connectionFactory.createConnection()).thenReturn(connection);
 
         // Mock session
-        when(connection.createSession(Matchers.anyBoolean(), Matchers.anyInt())).thenReturn(session);
+        when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
         return session;
     }
 

--- a/gmp-commands-records/src/test/java/edu/gemini/gmp/commands/records/MockFactory.java
+++ b/gmp-commands-records/src/test/java/edu/gemini/gmp/commands/records/MockFactory.java
@@ -2,10 +2,9 @@ package edu.gemini.gmp.commands.records;
 
 import edu.gemini.aspen.giapi.commands.*;
 import edu.gemini.gmp.top.Top;
-import org.mockito.Matchers;
 
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,14 +32,14 @@ public class MockFactory {
         Command preset_start = new Command(SequenceCommand.valueOf(cadName.toUpperCase()), Activity.PRESET_START, DefaultConfiguration.configurationBuilder().
                 withConfiguration("DATA_LABEL", "label").
                 build());
-        when(cs.sendCommand(eq(preset), Matchers.<CompletionListener>any(), anyLong())).thenReturn(HandlerResponse.ACCEPTED);
-        when(cs.sendCommand(eq(preset), Matchers.<CompletionListener>any())).thenReturn(HandlerResponse.ACCEPTED);
-        when(cs.sendCommand(eq(start), Matchers.<CompletionListener>any(), anyLong())).thenReturn(HandlerResponse.COMPLETED);
-        when(cs.sendCommand(eq(start), Matchers.<CompletionListener>any())).thenReturn(HandlerResponse.COMPLETED);
-        when(cs.sendCommand(eq(cancel), Matchers.<CompletionListener>any(), anyLong())).thenReturn(HandlerResponse.ACCEPTED);
-        when(cs.sendCommand(eq(cancel), Matchers.<CompletionListener>any())).thenReturn(HandlerResponse.ACCEPTED);
-        when(cs.sendCommand(eq(preset_start), Matchers.<CompletionListener>any(), anyLong())).thenReturn(HandlerResponse.COMPLETED);
-        when(cs.sendCommand(eq(preset_start), Matchers.<CompletionListener>any())).thenReturn(HandlerResponse.COMPLETED);
+        when(cs.sendCommand(eq(preset), any(CompletionListener.class), anyLong())).thenReturn(HandlerResponse.ACCEPTED);
+        when(cs.sendCommand(eq(preset), any(CompletionListener.class))).thenReturn(HandlerResponse.ACCEPTED);
+        when(cs.sendCommand(eq(start), any(CompletionListener.class), anyLong())).thenReturn(HandlerResponse.COMPLETED);
+        when(cs.sendCommand(eq(start), any(CompletionListener.class))).thenReturn(HandlerResponse.COMPLETED);
+        when(cs.sendCommand(eq(cancel), any(CompletionListener.class), anyLong())).thenReturn(HandlerResponse.ACCEPTED);
+        when(cs.sendCommand(eq(cancel), any(CompletionListener.class))).thenReturn(HandlerResponse.ACCEPTED);
+        when(cs.sendCommand(eq(preset_start), any(CompletionListener.class), anyLong())).thenReturn(HandlerResponse.COMPLETED);
+        when(cs.sendCommand(eq(preset_start), any(CompletionListener.class))).thenReturn(HandlerResponse.COMPLETED);
 
         return cs;
     }

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/Action.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/Action.java
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * of sequence command progress.
  *
  * The Action's ID must grow monotonically with each new action,
- * and there rules are defined to accept responses
+ * and there rules are sdefined to accept responses
  * to Actions only on certain allowed order.
  *
  * ActionManagerImpl takes care of handling that logic

--- a/gmp-commands/src/main/scala/edu/gemini/aspen/gmp/commands/model/osgi/Activator.scala
+++ b/gmp-commands/src/main/scala/edu/gemini/aspen/gmp/commands/model/osgi/Activator.scala
@@ -26,7 +26,7 @@ class Activator extends BundleActivator {
   var senderTracker: Option[ServiceTracker[ActionSender, _]] = None
   var actionManager: Option[ActionManagerImpl] = None
 
-  def start(context: BundleContext) {
+  def start(context: BundleContext):Unit = {
     val am = new ActionManagerImpl
     am.start()
     actionManager = Some(am)
@@ -55,7 +55,7 @@ class Activator extends BundleActivator {
     senderTracker.foreach(_.open())
   }
 
-  def stop(context: BundleContext) {
+  def stop(context: BundleContext):Unit = {
     (cuRegistration :: amRegistration :: csRegistration :: Nil).foreach(_.foreach(_.unregister))
     cuRegistration = None
     amRegistration = None
@@ -93,7 +93,7 @@ case class SequenceCommandExecutorFactory(builder: ActionMessageBuilder, manager
     }
   }
 
-  override def deleted(pid: String) {
+  override def deleted(pid: String):Unit = {
     for {
       s <- existingServices.remove(pid)
     } yield s.unregister()

--- a/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/SequenceCommandExecutorStrategyTest.java
+++ b/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/SequenceCommandExecutorStrategyTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 
 import static edu.gemini.aspen.giapi.commands.DefaultConfiguration.emptyConfiguration;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class SequenceCommandExecutorStrategyTest {

--- a/gmp-epics-access/src/test/java/edu/gemini/aspen/gmp/epics/impl/EpicsRequestHandlerImplTest.java
+++ b/gmp-epics-access/src/test/java/edu/gemini/aspen/gmp/epics/impl/EpicsRequestHandlerImplTest.java
@@ -8,9 +8,9 @@ import org.junit.Test;
 import javax.jms.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gmp-epics-access/src/test/java/edu/gemini/aspen/gmp/epics/jms/EpicsConfigRequestConsumerTest.java
+++ b/gmp-epics-access/src/test/java/edu/gemini/aspen/gmp/epics/jms/EpicsConfigRequestConsumerTest.java
@@ -11,9 +11,9 @@ import javax.jms.*;
 import java.util.Set;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class EpicsConfigRequestConsumerTest {
@@ -69,7 +69,7 @@ public class EpicsConfigRequestConsumerTest {
 
 
         consumer.onMessage(message);
-        
+
         verify(replyMessage).setBoolean(channelName, true);
         verify(messageProducer).send(destination,replyMessage);
     }

--- a/gmp-epics-access/src/test/java/edu/gemini/aspen/gmp/epics/jms/EpicsGetRequestConsumerTest.java
+++ b/gmp-epics-access/src/test/java/edu/gemini/aspen/gmp/epics/jms/EpicsGetRequestConsumerTest.java
@@ -21,7 +21,8 @@ import javax.jms.*;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,13 +44,15 @@ public class EpicsGetRequestConsumerTest {
 
         Queue destination = mock(Queue.class);
         when(session.createQueue(anyString())).thenReturn(destination);
+        Topic topic = mock(Topic.class);
+        when(session.createTopic(anyString())).thenReturn(topic);
         producer = mock(MessageProducer.class);
-        when(session.createProducer(any(Destination.class))).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
 
         BytesMessage mapMessage = mock(BytesMessage.class);
         when(session.createBytesMessage()).thenReturn(mapMessage);
         MessageConsumer messageConsumer = mock(MessageConsumer.class);
-        when(session.createConsumer(destination)).thenReturn(messageConsumer);
+        when(session.createConsumer(any(Destination.class))).thenReturn(messageConsumer);
     }
 
     @Test

--- a/gmp-epics-simulator/src/test/java/edu/gemini/aspen/gmp/epics/simulator/ChannelSimulatorTest.java
+++ b/gmp-epics-simulator/src/test/java/edu/gemini/aspen/gmp/epics/simulator/ChannelSimulatorTest.java
@@ -4,12 +4,12 @@ import edu.gemini.aspen.gmp.epics.EpicsRegistrar;
 import edu.gemini.aspen.gmp.epics.EpicsUpdate;
 import edu.gemini.aspen.gmp.epics.simulator.channels.SimulatedEpicsChannel;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -34,6 +34,6 @@ public class ChannelSimulatorTest {
 
         TimeUnit.MILLISECONDS.sleep(PASSES * updateRate);
 
-        verify(registrar, atLeast(PASSES - 2)).processEpicsUpdate(Matchers.<EpicsUpdate<?>>anyObject());
+        verify(registrar, atLeast(PASSES - 2)).processEpicsUpdate(any(EpicsUpdate.class));
     }
 }

--- a/gmp-epics-simulator/src/test/java/edu/gemini/aspen/gmp/epics/simulator/EpicsSimulatorComponentTest.java
+++ b/gmp-epics-simulator/src/test/java/edu/gemini/aspen/gmp/epics/simulator/EpicsSimulatorComponentTest.java
@@ -4,7 +4,6 @@ import edu.gemini.aspen.gmp.epics.EpicsRegistrar;
 import edu.gemini.aspen.gmp.epics.EpicsUpdate;
 import org.junit.After;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +24,7 @@ public class EpicsSimulatorComponentTest {
         // Wait for one update
         TimeUnit.MILLISECONDS.sleep(1100L);
 
-        verify(registrar, atLeastOnce()).processEpicsUpdate(Matchers.<EpicsUpdate<?>>anyObject());
+        verify(registrar, atLeastOnce()).processEpicsUpdate(any(EpicsUpdate.class));
     }
 
     @Test
@@ -38,7 +37,7 @@ public class EpicsSimulatorComponentTest {
         // Wait for one update
         TimeUnit.MILLISECONDS.sleep(1100L);
 
-        verifyZeroInteractions(registrar);
+        verifyNoInteractions(registrar);
     }
 
     @After

--- a/gmp-epics-to-status/src/main/scala/edu/gemini/aspen/gmp/epicstostatus/osgi/EpicsToStatusFactory.scala
+++ b/gmp-epics-to-status/src/main/scala/edu/gemini/aspen/gmp/epicstostatus/osgi/EpicsToStatusFactory.scala
@@ -46,8 +46,8 @@ class EpicsToStatusFactory(val context: BundleContext, reader: EpicsReader, prov
   }
 
   def stopServices(): Unit = {
-    import scala.collection.JavaConversions._
-    for (pid <- existingServices.keySet) {
+    import scala.jdk.CollectionConverters._
+    for (pid <- existingServices.keySet.asScala) {
       deleted(pid)
     }
   }

--- a/gmp-pcs-updater/src/test/java/edu/gemini/aspen/gmp/pcs/model/PcsUpdaterComponentTest.java
+++ b/gmp-pcs-updater/src/test/java/edu/gemini/aspen/gmp/pcs/model/PcsUpdaterComponentTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import java.util.Hashtable;
 import java.util.List;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class PcsUpdaterComponentTest {
@@ -44,7 +44,7 @@ public class PcsUpdaterComponentTest {
         PcsUpdaterComponent component = buildComponentInSimulation();
 
         component.startComponent();
-        verifyZeroInteractions(epicsWriter);
+        verifyNoInteractions(epicsWriter);
     }
 
     private PcsUpdaterComponent buildComponentInSimulation() {
@@ -57,7 +57,7 @@ public class PcsUpdaterComponentTest {
         doThrow(new EpicsException("Test exception", new RuntimeException())).when(epicsWriter).getDoubleChannel(anyString());
 
         component.startComponent();
-        verifyZeroInteractions(epicsWriter);
+        verifyNoInteractions(epicsWriter);
     }
 
     @Test
@@ -81,7 +81,7 @@ public class PcsUpdaterComponentTest {
         component.startComponent();
 
         component.stopComponent();
-        verifyZeroInteractions(epicsWriter);
+        verifyNoInteractions(epicsWriter);
     }
 
     @Test

--- a/gmp-pcs-updater/src/test/java/edu/gemini/aspen/gmp/pcs/model/updaters/EpicsPcsUpdaterTest.java
+++ b/gmp-pcs-updater/src/test/java/edu/gemini/aspen/gmp/pcs/model/updaters/EpicsPcsUpdaterTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**

--- a/gmp-services/src/main/scala/edu/gemini/aspen/gmp/services/osgi/SimplePropertyHolderFactory.scala
+++ b/gmp-services/src/main/scala/edu/gemini/aspen/gmp/services/osgi/SimplePropertyHolderFactory.scala
@@ -33,8 +33,8 @@ class SimplePropertyHolderFactory(val context: BundleContext) extends ManagedSer
   }
 
   def stopServices(): Unit = {
-    import scala.collection.JavaConversions._
-    for (pid <- existingServices.keySet) {
+    import scala.jdk.CollectionConverters._
+    for (pid <- existingServices.keySet.asScala) {
       deleted(pid)
     }
   }

--- a/gmp-services/src/test/java/edu/gemini/aspen/gmp/services/MockedJmsArtifactsTestBase.java
+++ b/gmp-services/src/test/java/edu/gemini/aspen/gmp/services/MockedJmsArtifactsTestBase.java
@@ -1,13 +1,12 @@
 package edu.gemini.aspen.gmp.services;
 
 import edu.gemini.jms.api.JmsProvider;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import javax.jms.*;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,9 +34,9 @@ public class MockedJmsArtifactsTestBase {
         session = mockSessionCreation();
 
         producer = Mockito.mock(MessageProducer.class);
-        when(session.createProducer(Matchers.<Destination>anyObject())).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
         consumer = Mockito.mock(MessageConsumer.class);
-        when(session.createConsumer(Matchers.<Destination>anyObject())).thenReturn(consumer);
+        when(session.createConsumer(any(Destination.class))).thenReturn(consumer);
 
         Queue queue = mock(Queue.class);
         when(session.createQueue(anyString())).thenReturn(queue);
@@ -50,7 +49,7 @@ public class MockedJmsArtifactsTestBase {
         when(session.createMapMessage()).thenReturn(mapMessage);
 
         TextMessage textMessage = Mockito.mock(TextMessage.class);
-        when(session.createTextMessage(any(String.class))).thenReturn(textMessage);
+        when(session.createTextMessage(anyString())).thenReturn(textMessage);
     }
 
     private Session mockSessionCreation() throws JMSException {
@@ -63,7 +62,7 @@ public class MockedJmsArtifactsTestBase {
         when(connectionFactory.createConnection()).thenReturn(connection);
 
         // Mock session
-        when(connection.createSession(Matchers.anyBoolean(), Matchers.anyInt())).thenReturn(session);
+        when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
         return session;
     }
 }

--- a/gmp-services/src/test/java/edu/gemini/aspen/gmp/services/properties/PropertyServiceTest.java
+++ b/gmp-services/src/test/java/edu/gemini/aspen/gmp/services/properties/PropertyServiceTest.java
@@ -24,6 +24,7 @@ public class PropertyServiceTest extends MockedJmsArtifactsTestBase {
     public void setUp() throws Exception {
         propertyHolder = mock(PropertyHolder.class);
         requestedProperty = "GMP_HOST_NAME";
+        when(propertyHolder.getProperty(requestedProperty)).thenReturn("");
     }
 
     @Test
@@ -72,7 +73,7 @@ public class PropertyServiceTest extends MockedJmsArtifactsTestBase {
         propertyService.startJms(provider);
         propertyService.process(request);
 
-        verifyZeroInteractions(session);
+        verifyNoInteractions(session);
     }
 
     @Test

--- a/gmp-status-simulator/src/main/scala/edu/gemini/aspen/gmp/status/simulator/osgi/StatusSimulatorFactory.scala
+++ b/gmp-status-simulator/src/main/scala/edu/gemini/aspen/gmp/status/simulator/osgi/StatusSimulatorFactory.scala
@@ -32,8 +32,8 @@ class StatusSimulatorFactory(context: BundleContext, top: Top) extends ManagedSe
   }
 
   def stopServices(): Unit = {
-    import scala.collection.JavaConversions._
-    for (pid <- existingServices.keySet) {
+    import scala.jdk.CollectionConverters._
+    for (pid <- existingServices.keySet.asScala) {
       deleted(pid)
     }
   }

--- a/gmp-status-simulator/src/test/java/edu/gemini/aspen/gmp/status/simulator/StatusSimulatorTest.java
+++ b/gmp-status-simulator/src/test/java/edu/gemini/aspen/gmp/status/simulator/StatusSimulatorTest.java
@@ -4,7 +4,6 @@ import edu.gemini.gmp.top.Top;
 import edu.gemini.jms.api.JmsProvider;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import javax.jms.*;
@@ -13,7 +12,8 @@ import java.io.FileNotFoundException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.*;
 
 public class StatusSimulatorTest {
@@ -52,7 +52,7 @@ public class StatusSimulatorTest {
 
         TimeUnit.MILLISECONDS.sleep(300);
 
-        verify(session, times(3)).createProducer(any(Destination.class));
+        verify(session, times(3)).createProducer(or(any(Destination.class), isNull()));
     }
 
     @Test
@@ -74,9 +74,9 @@ public class StatusSimulatorTest {
         session = mockSessionCreation();
 
         producer = mock(MessageProducer.class);
-        when(session.createProducer(Matchers.<Destination>anyObject())).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
         consumer = mock(MessageConsumer.class);
-        when(session.createConsumer(Matchers.<Destination>anyObject())).thenReturn(consumer);
+        when(session.createConsumer(any(Destination.class))).thenReturn(consumer);
 
         Queue queue = mock(Queue.class);
         when(session.createQueue(anyString())).thenReturn(queue);
@@ -100,7 +100,7 @@ public class StatusSimulatorTest {
         when(connectionFactory.createConnection()).thenReturn(connection);
 
         // Mock session
-        when(connection.createSession(Matchers.anyBoolean(), Matchers.anyInt())).thenReturn(session);
+        when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
         return session;
     }
 

--- a/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/InMemoryStatusItemTranslator.scala
+++ b/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/InMemoryStatusItemTranslator.scala
@@ -15,25 +15,25 @@ import java.util.logging.Logger
 class InMemoryStatusItemTranslator(top: Top, aggregate: StatusHandlerAggregate, statusDatabase: StatusDatabaseService, xmlFileName: String) extends AbstractStatusItemTranslator(top, xmlFileName) with StatusItemTranslator {
   private final val LOG: Logger = Logger.getLogger(classOf[InMemoryStatusItemTranslator].getName)
 
-   def start {
+   def start:Unit = {
     //super.start()
     initItems
   }
 
-  protected def initItems {
-    import scala.collection.JavaConversions._
-    for (item <- statusDatabase.getAll) {
+  protected def initItems: Unit = {
+    import scala.jdk.CollectionConverters._
+    for (item <- statusDatabase.getAll.asScala) {
       update(item)
     }
   }
 
-  def stop {
+  def stop:Unit = {
     LOG.info("Start stop")
     //super.stop
     LOG.info("End stop")
   }
 
-  def update[T](item: StatusItem[T]) {
+  def update[T](item: StatusItem[T]): Unit = {
     for (newItem <- translate(item)) {
       LOG.finer(s"Publishing translated status item: ${newItem.getName}")
       aggregate.update(newItem)

--- a/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/JmsStatusItemTranslatorImpl.scala
+++ b/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/JmsStatusItemTranslatorImpl.scala
@@ -20,9 +20,9 @@ import java.util.logging.Logger
 case class JmsStatusItemTranslatorImpl(to: Top, xmlFileNam: String) extends AbstractStatusItemTranslator(to, xmlFileNam) with JmsArtifact with StatusItemTranslator {
   private final val LOG: Logger = Logger.getLogger(classOf[JmsStatusItemTranslatorImpl].getName)
 
-   def start {
+   def start:Unit = {
     //super.start
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     for (status <- config.statuses) {
       setters.put(to.buildStatusItemName(status.getOriginalName), new StatusSetterImpl(this.getName + status.getOriginalName, to.buildStatusItemName(status.getOriginalName)))
     }
@@ -33,12 +33,12 @@ case class JmsStatusItemTranslatorImpl(to: Top, xmlFileNam: String) extends Abst
   /**
    * Connect JMS on the StatusSetters
    */
-  private def initSetters {
+  private def initSetters:Unit = {
     /*val executor: ScheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1)
     executor.execute(new Runnable {
-      def run {
+      def run:Unit = {
         waitFor(validateDone)
-        import scala.collection.JavaConversions._
+        import scala.jdk.CollectionConverters._
         for (ss <- setters.values) {
           try {
             ss.startJms(provider)
@@ -54,28 +54,28 @@ case class JmsStatusItemTranslatorImpl(to: Top, xmlFileNam: String) extends Abst
     })*/
   }
 
-  def stop {
+  def stop:Unit = {
     validateDone.set(false)
     //super.stop
   }
 
-  override def startJms(provider: JmsProvider) {
+  override def startJms(provider: JmsProvider):Unit = {
     getter.startJms(provider)
     this.provider = provider
     initSetters
   }
 
-  override def stopJms {
+  override def stopJms:Unit = {
     //jmsStarted.set(false)
     getter.stopJms
-    import scala.collection.JavaConversions._
-    for (ss <- setters.values) {
+    import scala.jdk.CollectionConverters._
+    for (ss <- setters.values.asScala) {
       ss.stopJms
     }
   }
 
-  def update[T](item: StatusItem[T]) {
-    import scala.collection.JavaConversions._
+  def update[T](item: StatusItem[T]):Unit = {
+    import scala.jdk.CollectionConverters._
     for (newItem <- translate(item)) {
       try {
         setters.get(item.getName).setStatusItem(newItem)

--- a/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/LocalStatusItemTranslator.scala
+++ b/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/LocalStatusItemTranslator.scala
@@ -16,13 +16,13 @@ import java.util.logging.Logger
 class LocalStatusItemTranslator(top: Top, aggregate: StatusHandlerAggregate, xmlFileName: String) extends AbstractStatusItemTranslator(top, xmlFileName) with JmsArtifact with StatusItemTranslator {
   private final val LOG: Logger = Logger.getLogger(classOf[LocalStatusItemTranslator].getName)
 
-   def start {
+   def start:Unit = {
     LOG.finer("Start validate")
     //initItems
     LOG.finer("End validate")
   }
 
-  def update[T](item: StatusItem[T]) {
+  def update[T](item: StatusItem[T]):Unit = {
     for (newItem <- translate(item)) {
       LOG.fine(s"Publishing translated status item: $newItem")
       aggregate.update(newItem)

--- a/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/StatusItemTranslatorConfiguration.scala
+++ b/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/StatusItemTranslatorConfiguration.scala
@@ -5,7 +5,7 @@ import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.SchemaFactory
 import java.io.InputStream
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import edu.gemini.gmp.status.translator.generated.{StatusType, TranslateStatus}
 
 /**

--- a/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/osgi/Activator.scala
+++ b/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/osgi/Activator.scala
@@ -9,7 +9,7 @@ import org.osgi.framework.{BundleActivator, BundleContext, ServiceRegistration}
 import org.osgi.service.cm.ManagedServiceFactory
 import org.osgi.util.tracker.ServiceTracker
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 class Activator extends BundleActivator {
   var serviceRegistration: Option[ServiceRegistration[ManagedServiceFactory]] = None
@@ -26,7 +26,15 @@ class Activator extends BundleActivator {
       }
       topTracker = Some(track[Top, Top](context) { top =>
         val f = LocalTranslatorFactory(top, aggregate, context)
-        serviceRegistration = Some(context.registerService(classOf[ManagedServiceFactory], f, new java.util.Hashtable[String, Any](Map("service.pid" -> classOf[LocalStatusItemTranslator].getName))))
+        serviceRegistration = Some(
+          context.registerService(
+            classOf[ManagedServiceFactory],
+            f,
+            new java.util.Hashtable[String, Any](
+              Map("service.pid" -> classOf[LocalStatusItemTranslator].getName).asJava
+            )
+          )
+        )
         top
       } { _ =>
         serviceRegistration.foreach(_.unregister())

--- a/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/osgi/LocalTranslatorFactory.scala
+++ b/gmp-status-translator/src/main/scala/edu/gemini/gmp/status/translator/osgi/LocalTranslatorFactory.scala
@@ -39,7 +39,7 @@ case class LocalTranslatorFactory(top: Top, aggregate: StatusHandlerAggregate, c
     }
   }
 
-  override def deleted(pid: String) {
+  override def deleted(pid: String):Unit = {
     for {
       s <- existingServices.remove(pid)
     } yield s.unregister()

--- a/gmp-status-translator/src/test/scala/edu/gemini/gmp/status/translator/InMemoryStatusItemTranslatorTest.scala
+++ b/gmp-status-translator/src/test/scala/edu/gemini/gmp/status/translator/InMemoryStatusItemTranslatorTest.scala
@@ -10,24 +10,24 @@ import edu.gemini.gmp.top.TopImpl
 import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 
 /**
  * Class InMemoryStatusItemTranslatorTest
  */
 class InMemoryStatusItemTranslatorTest {
-  @Test def testSimpleConfiguration() {
+  @Test def testSimpleConfiguration():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
     val aggregate = mock(classOf[StatusHandlerAggregate])
     val translator = new InMemoryStatusItemTranslator(top, aggregate, db, file)
     translator.start
-    verifyZeroInteractions(aggregate)
+    verifyNoInteractions(aggregate)
   }
 
-  @Test def testTranslations() {
+  @Test def testTranslations():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
@@ -41,7 +41,7 @@ class InMemoryStatusItemTranslatorTest {
     assertEquals(good.getValue, translated(0).getValue)
   }
 
-  @Test def testMultipleTranslationsSameOrigin() {
+  @Test def testMultipleTranslationsSameOrigin():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
@@ -58,7 +58,7 @@ class InMemoryStatusItemTranslatorTest {
     assertEquals(second.getValue, translated(0).getValue)
   }
 
-  @Test def testMultipleOriginsSameTranslation() {
+  @Test def testMultipleOriginsSameTranslation():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
@@ -75,7 +75,7 @@ class InMemoryStatusItemTranslatorTest {
     assertEquals(second.getValue, translated(1).getValue)
   }
 
-  @Test def testTranslationUpdate() {
+  @Test def testTranslationUpdate():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
@@ -87,7 +87,7 @@ class InMemoryStatusItemTranslatorTest {
     verify(aggregate).update(any(classOf[StatusItem[_]]))
   }
 
-  @Test def testTranslationTwiceUpdate() {
+  @Test def testTranslationTwiceUpdate():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
@@ -98,7 +98,7 @@ class InMemoryStatusItemTranslatorTest {
     verify(aggregate, times(2)).update(any(classOf[StatusItem[_]]))
   }
 
-  @Test def testTranslateOnStart() {
+  @Test def testTranslateOnStart():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
@@ -112,7 +112,7 @@ class InMemoryStatusItemTranslatorTest {
     verify(aggregate, times(1)).update(any(classOf[StatusItem[_]]))
   }
 
-  @Test def testTranslateString() {
+  @Test def testTranslateString():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase
@@ -131,7 +131,7 @@ class InMemoryStatusItemTranslatorTest {
     verify(aggregate, times(1)).update(any(classOf[StatusItem[_]]))
   }
 
-  @Test def testTranslateStringDefault() {
+  @Test def testTranslateStringDefault():Unit = {
     val top = new TopImpl("gpi", "gpi")
     val file = getClass.getResource("status-translator.xml").getFile
     val db = new StatusDatabase

--- a/gmp-status-translator/src/test/scala/edu/gemini/gmp/status/translator/StatusItemTranslatorConfigurationTest.scala
+++ b/gmp-status-translator/src/test/scala/edu/gemini/gmp/status/translator/StatusItemTranslatorConfigurationTest.scala
@@ -12,7 +12,7 @@ import org.junit.Assert.assertEquals
  *         Date: 4/9/12
  */
 class StatusItemTranslatorConfigurationTest {
-  @Test def testSimpleConfiguration() {
+  @Test def testSimpleConfiguration():Unit = {
     val configuration: StatusItemTranslatorConfiguration = new StatusItemTranslatorConfiguration(getClass.getResourceAsStream("status-translator.xml"))
     val statuses = configuration.statuses
     assertEquals(7, statuses.size)

--- a/gmp-tcs-context/src/main/scala/edu/gemini/aspen/gmp/tcs/osgi/TcsContextComponentFactory.scala
+++ b/gmp-tcs-context/src/main/scala/edu/gemini/aspen/gmp/tcs/osgi/TcsContextComponentFactory.scala
@@ -43,8 +43,8 @@ class TcsContextComponentFactory(context: BundleContext, reader: EpicsReader) ex
   }
 
   def stopServices(): Unit = {
-    import scala.collection.JavaConversions._
-    for (pid <- existingServices.keySet) {
+    import scala.jdk.CollectionConverters._
+    for (pid <- existingServices.keySet.asScala) {
       deleted(pid)
     }
   }

--- a/gmp-tcs-context/src/test/java/edu/gemini/aspen/gmp/tcs/jms/JmsTcsContextDispatcherTest.java
+++ b/gmp-tcs-context/src/test/java/edu/gemini/aspen/gmp/tcs/jms/JmsTcsContextDispatcherTest.java
@@ -3,12 +3,12 @@ package edu.gemini.aspen.gmp.tcs.jms;
 import edu.gemini.aspen.gmp.tcs.jms.JmsTcsContextDispatcher;
 import edu.gemini.jms.api.JmsProvider;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import javax.jms.*;
 
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.*;
 
 public class JmsTcsContextDispatcherTest {
@@ -27,7 +27,7 @@ public class JmsTcsContextDispatcherTest {
         BytesMessage bytesMessage = mock(BytesMessage.class);
         when(session.createBytesMessage()).thenReturn(bytesMessage);
         MessageProducer producer = mock(MessageProducer.class);
-        when(session.createProducer(Matchers.<Destination>anyObject())).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
 
         tcsContextDispatcher.startJms(provider);
 
@@ -44,6 +44,6 @@ public class JmsTcsContextDispatcherTest {
         Destination destination = mock(Destination.class);
         tcsContextDispatcher.send(context, destination);
 
-        verifyZeroInteractions(destination);
+        verifyNoInteractions(destination);
     }
 }

--- a/gmp-tcs-context/src/test/java/edu/gemini/aspen/gmp/tcs/jms/TcsContextRequestListenerTest.java
+++ b/gmp-tcs-context/src/test/java/edu/gemini/aspen/gmp/tcs/jms/TcsContextRequestListenerTest.java
@@ -11,7 +11,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class TcsContextRequestListenerTest {
@@ -49,7 +49,7 @@ public class TcsContextRequestListenerTest {
 
         listener.onMessage(message);
 
-        verifyZeroInteractions(contextDispatcher);
+        verifyNoInteractions(contextDispatcher);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class TcsContextRequestListenerTest {
 
         listener.onMessage(message);
 
-        verifyZeroInteractions(contextDispatcher);
+        verifyNoInteractions(contextDispatcher);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class TcsContextRequestListenerTest {
 
         listener.onMessage(message);
 
-        verifyZeroInteractions(contextDispatcher);
+        verifyNoInteractions(contextDispatcher);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/gmp-tcs-context/src/test/java/edu/gemini/aspen/gmp/tcs/model/TcsContextComponentTest.java
+++ b/gmp-tcs-context/src/test/java/edu/gemini/aspen/gmp/tcs/model/TcsContextComponentTest.java
@@ -4,11 +4,11 @@ import edu.gemini.epics.EpicsReader;
 import edu.gemini.jms.api.JmsProvider;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import javax.jms.*;
 
 import static edu.gemini.aspen.gmp.tcs.model.EpicsTcsContextFetcher.TCS_CONTEXT_CHANNEL;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.*;
 
 public class TcsContextComponentTest {
@@ -29,7 +29,7 @@ public class TcsContextComponentTest {
         BytesMessage bytesMessage = mock(BytesMessage.class);
         when(session.createBytesMessage()).thenReturn(bytesMessage);
         MessageProducer producer = mock(MessageProducer.class);
-        when(session.createProducer(Matchers.<Destination>anyObject())).thenReturn(producer);
+        when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
 
         reader = mock(EpicsReader.class);
     }
@@ -40,7 +40,7 @@ public class TcsContextComponentTest {
         component.startJms(provider);
 
         verify(provider, times(2)).getConnectionFactory();
-        verifyZeroInteractions(reader);
+        verifyNoInteractions(reader);
     }
 
     @Test

--- a/gpi/gpi-observation-status/src/main/scala/edu/gemini/gpi/observationstatus/GpiItemTranslator.scala
+++ b/gpi/gpi-observation-status/src/main/scala/edu/gemini/gpi/observationstatus/GpiItemTranslator.scala
@@ -53,13 +53,13 @@ class GpiItemTranslator(top: Top, statusSetter: StatusSetter) extends StatusHand
     }
   }
 
-  private def updateStatus() {
+  private def updateStatus():Unit = {
     statusSetter.setStatusItem(new BasicStatus[Int](lightOnStatus, current.isOn))
   }
 
-  override def startJms(provider: JmsProvider) {
+  override def startJms(provider: JmsProvider):Unit = {
     getter.startJms(provider)
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     Future.apply {
       for {
         si <- getter.getAllStatusItems
@@ -68,5 +68,5 @@ class GpiItemTranslator(top: Top, statusSetter: StatusSetter) extends StatusHand
   }
 
 
-  override def stopJms() {}
+  override def stopJms():Unit = {}
 }

--- a/gpi/gpi-observation-status/src/main/scala/edu/gemini/gpi/observationstatus/ObservationEventsListener.scala
+++ b/gpi/gpi-observation-status/src/main/scala/edu/gemini/gpi/observationstatus/ObservationEventsListener.scala
@@ -45,11 +45,11 @@ class ObservationEventsListener(gmpTop: Top, statusSetter: StatusSetter, statusD
 
   val timer = new Timer()
 
-  def invalidate() {
+  def invalidate():Unit = {
     cache.invalidateAll()
   }
 
-  def gdsEvent(event: GDSNotification) {
+  def gdsEvent(event: GDSNotification):Unit = {
     event match {
       case GDSStartObservation(dataLabel)     =>
         val coAdds = Option(statusDB.getStatusItem[Int](coAddsStatus)).map(_.getValue)
@@ -125,7 +125,7 @@ class ObservationEventsListener(gmpTop: Top, statusSetter: StatusSetter, statusD
   }
 
   case object TimerRemoval extends RemovalListener[DataLabel, ObsTimerTask] {
-    override def onRemoval(removalNotification: RemovalNotification[DataLabel, ObsTimerTask]) {
+    override def onRemoval(removalNotification: RemovalNotification[DataLabel, ObsTimerTask]):Unit = {
       if (removalNotification.getValue.isRunning) {
         removalNotification.getValue.endObservation()
       }

--- a/gpi/gpi-observation-status/src/main/scala/edu/gemini/gpi/observationstatus/osgi/Activator.scala
+++ b/gpi/gpi-observation-status/src/main/scala/edu/gemini/gpi/observationstatus/osgi/Activator.scala
@@ -13,7 +13,7 @@ import org.osgi.framework.{BundleActivator, BundleContext, ServiceRegistration}
 import org.osgi.service.event.{EventConstants, EventHandler}
 import org.osgi.util.tracker.ServiceTracker
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 class Activator extends BundleActivator {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -201,7 +201,7 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor_2.12</artifactId>
+            <artifactId>akka-actor_2.13</artifactId>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>

--- a/integration-tests/src/test/java/edu/gemini/aspen/integrationtests/GDSIntegrationBase.java
+++ b/integration-tests/src/test/java/edu/gemini/aspen/integrationtests/GDSIntegrationBase.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.ops4j.pax.exam.CoreOptions.*;
-import static scala.collection.JavaConversions.seqAsJavaList;
+import static scala.jdk.CollectionConverters.seqAsJavaList;
 
 /**
  * Base class for the integration tests related to the GDS

--- a/integration-tests/src/test/scala/edu/gemini/aspen/integrationtests/EpicsStressIT.scala
+++ b/integration-tests/src/test/scala/edu/gemini/aspen/integrationtests/EpicsStressIT.scala
@@ -17,7 +17,7 @@ class EpicsStressIT {
   var reader: EpicsReader = _
 
   @Before
-  def setup() {
+  def setup():Unit = {
     System.setProperty("com.cosylab.epics.caj.CAJContext.addr_list", "127.0.0.1")
     System.setProperty("com.cosylab.epics.caj.CAJContext.auto_addr_list", "false")
 
@@ -27,7 +27,7 @@ class EpicsStressIT {
   }
 
   @Test
-  def testConcurrentRead() {
+  def testConcurrentRead():Unit = {
     val testFile = this.getClass.getResource("cas501channels.xml").toURI.toURL.getFile
     val channels = new ChannelBuilder(testFile).channels
     val Nactors = 10
@@ -54,7 +54,7 @@ class EpicsStressIT {
   }
 
   @Test
-  def testConcurrentReadWithEpicsReader() {
+  def testConcurrentReadWithEpicsReader():Unit = {
     val testFile = this.getClass.getResource("cas501channels.xml").toURI.toURL.getFile
     val channels = new ChannelBuilder(testFile).channels
 

--- a/jms-api/src/test/java/edu/gemini/jms/api/AbstractMapMessageBuilderTest.java
+++ b/jms-api/src/test/java/edu/gemini/jms/api/AbstractMapMessageBuilderTest.java
@@ -2,14 +2,13 @@ package edu.gemini.jms.api;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
 
 import java.util.Map;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class AbstractMapMessageBuilderTest {
@@ -30,7 +29,7 @@ public class AbstractMapMessageBuilderTest {
 
     @Test
     public void testFillStringBasedMessage() throws JMSException {
-        doThrow(new JMSException("Exception")).when(message).setObject(anyString(), Matchers.<Object>anyObject());
+        doThrow(new JMSException("Exception")).when(message).setObject(anyString(), any());
         messageBuilder.setStringBasedMessageBody(message, stringMessageContent);
 
         verify(message, times(messageContent.size())).setString(anyString(), anyString());
@@ -60,12 +59,12 @@ public class AbstractMapMessageBuilderTest {
     public void testSetMessageProperties() throws JMSException {
         messageBuilder.setMessageProperties(message, messageProperties);
 
-        verify(message, times(messageProperties.size())).setObjectProperty(anyString(), Matchers.<Object>anyObject());
+        verify(message, times(messageProperties.size())).setObjectProperty(anyString(), any());
     }
 
     @Test(expected = MessagingException.class)
     public void testSetMessagePropertiesWithException() throws JMSException {
-        doThrow(new JMSException("Exception")).when(message).setObjectProperty(anyString(), Matchers.<Object>anyObject());
+        doThrow(new JMSException("Exception")).when(message).setObjectProperty(anyString(), any());
 
         messageBuilder.setMessageProperties(message, messageProperties);
     }
@@ -74,12 +73,12 @@ public class AbstractMapMessageBuilderTest {
     public void testBuildMessage() throws JMSException {
         messageBuilder.setMessageBody(message, messageContent);
 
-        verify(message, times(messageContent.size())).setObject(anyString(), Matchers.<Object>anyObject());
+        verify(message, times(messageContent.size())).setObject(anyString(), any());
     }
 
     @Test(expected = MessagingException.class)
     public void testBuildMessageWithException() throws JMSException {
-        doThrow(new JMSException("Exception")).when(message).setObject(anyString(), Matchers.<Object>anyObject());
+        doThrow(new JMSException("Exception")).when(message).setObject(anyString(), any());
 
         messageBuilder.setMessageBody(message, messageContent);
     }

--- a/jms-api/src/test/java/edu/gemini/jms/api/JmsArtifactTestBase.java
+++ b/jms-api/src/test/java/edu/gemini/jms/api/JmsArtifactTestBase.java
@@ -1,7 +1,6 @@
 package edu.gemini.jms.api;
 
 import org.junit.Before;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import javax.jms.Connection;
@@ -15,7 +14,8 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,9 +44,9 @@ public class JmsArtifactTestBase {
         session = mockSessionCreation();
 
         producer = Mockito.mock(MessageProducer.class);
-        Mockito.when(session.createProducer(Matchers.<Destination>anyObject())).thenReturn(producer);
+        Mockito.when(session.createProducer(or(any(Destination.class), isNull()))).thenReturn(producer);
         MessageConsumer consumer = Mockito.mock(MessageConsumer.class);
-        Mockito.when(session.createConsumer(Matchers.<Destination>anyObject())).thenReturn(consumer);
+        Mockito.when(session.createConsumer(any(Destination.class))).thenReturn(consumer);
 
         Queue queue = mock(Queue.class);
         when(session.createQueue(anyString())).thenReturn(queue);
@@ -55,6 +55,8 @@ public class JmsArtifactTestBase {
         when(session.createTopic(anyString())).thenReturn(topic);
 
         mapMessage = Mockito.mock(MapMessage.class);
+        Destination destination = mock(Destination.class);
+        when(mapMessage.getJMSReplyTo()).thenReturn(destination);
         when(session.createMapMessage()).thenReturn(mapMessage);
     }
 
@@ -70,7 +72,7 @@ public class JmsArtifactTestBase {
         Mockito.when(connectionFactory.createConnection()).thenReturn(connection);
 
         // Mock session
-        Mockito.when(connection.createSession(Matchers.anyBoolean(), Matchers.anyInt())).thenReturn(session);
+        Mockito.when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
         return session;
     }
 }

--- a/jms-api/src/test/java/edu/gemini/jms/api/JmsMapMessageSenderReplyTest.java
+++ b/jms-api/src/test/java/edu/gemini/jms/api/JmsMapMessageSenderReplyTest.java
@@ -3,7 +3,6 @@ package edu.gemini.jms.api;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
@@ -15,7 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -64,7 +63,7 @@ public class JmsMapMessageSenderReplyTest extends JmsArtifactTestBase {
         String reply = sender.sendMessageWithReply(destinationData, mapMessageBuilder, 1000);
 
         assertEquals("GMP.TOPIC", reply);
-        verify(producer).send(Matchers.<Topic>anyObject(), eq(mapMessage));
+        verify(producer).send(any(Topic.class), eq(mapMessage));
 
         assertTrue(called.get());
     }

--- a/jms-api/src/test/java/edu/gemini/jms/api/JmsMapMessageSenderTest.java
+++ b/jms-api/src/test/java/edu/gemini/jms/api/JmsMapMessageSenderTest.java
@@ -3,7 +3,6 @@ package edu.gemini.jms.api;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
@@ -13,7 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -63,7 +62,7 @@ public class JmsMapMessageSenderTest extends JmsArtifactTestBase {
 
         // Verify the message has been sent
         assertNotNull(sentMessage);
-        verify(producer).send(Matchers.<Topic>anyObject(), eq(mapMessage));
+        verify(producer).send(any(Topic.class), eq(mapMessage));
         assertTrue(called.get());
 
         sender.stopJms();

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,13 @@
         <pax-web.version>6.1.2</pax-web.version>
         <pax-logging.version>1.10.1</pax-logging.version>
         <pax-runner.version>1.9.0</pax-runner.version>
-        <scala-lang.version>2.12.4</scala-lang.version>
-        <scalatest.version>3.0.5</scalatest.version>
+        <scala-lang.version>2.13.4</scala-lang.version>
+        <scalatest.version>3.2.2</scalatest.version>
+        <scalatestplus-junit.version>3.2.4.0-M1</scalatestplus-junit.version>
+        <scalatestplus-mockito.version>3.2.2.0</scalatestplus-mockito.version>
         <scala-plugin.version>3.3.2</scala-plugin.version>
-        <junit.version>4.10</junit.version>
+        <mockito.version>3.4.6</mockito.version>
+        <junit.version>4.13.2</junit.version>
         <felix.framework.version>5.4.0</felix.framework.version>
         <scala.xml.version>2.0.0-M2</scala.xml.version>
 
@@ -641,8 +644,20 @@
             <!-- Testing dependencies -->
             <dependency>
                 <groupId>org.scalatest</groupId>
-                <artifactId>scalatest_2.12</artifactId>
+                <artifactId>scalatest_2.13</artifactId>
                 <version>${scalatest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.scalatestplus</groupId>
+                <artifactId>junit-4-13_2.13</artifactId>
+                <version>${scalatestplus-junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.scalatestplus</groupId>
+                <artifactId>mockito-3-4_2.13</artifactId>
+                <version>${scalatestplus-mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -653,8 +668,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.9.5</version>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -778,12 +793,12 @@
             </dependency>
             <dependency>
                 <groupId>org.scala-lang.modules</groupId>
-                <artifactId>scala-parser-combinators_2.12</artifactId>
+                <artifactId>scala-parser-combinators_2.13</artifactId>
                 <version>1.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang.modules</groupId>
-                <artifactId>scala-xml_2.12</artifactId>
+                <artifactId>scala-xml_2.13</artifactId>
                 <version>${scala.xml.version}</version>
             </dependency>
 
@@ -828,11 +843,19 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.12</artifactId>
+            <artifactId>scalatest_2.13</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>junit-4-13_2.13</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>mockito-3-4_2.13</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>gsbase</groupId>


### PR DESCRIPTION
Updated Scala dependency to use 2.13. The update carried other packaged, namely:
    scalatest.junit and scalatest.mock were replaced by scalatestplus.junit-4-13_2.13 and scalatestplus.mockito-3-4_2.13
    junit version was updated to 4.13.2
    mockito-all was replaced by mockito-core, and version updated to 3.4.6