### PR TITLE
Switch to an util osgi lib compatible with scala 2.13

### DIFF
--- a/gmp-commands-jms-bridge/pom.xml
+++ b/gmp-commands-jms-bridge/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>giapi-test-support</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>edu.gemini.ocs</groupId>
+            <artifactId>edu-gemini-util-osgi_2.13</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/gmp-commands/pom.xml
+++ b/gmp-commands/pom.xml
@@ -46,8 +46,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>edu.gemini.util.osgi</groupId>
-            <artifactId>osgi</artifactId>
+            <groupId>edu.gemini.ocs</groupId>
+            <artifactId>edu-gemini-util-osgi_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/gmp-epics-to-status/pom.xml
+++ b/gmp-epics-to-status/pom.xml
@@ -56,8 +56,8 @@
             <artifactId>giapi-status-setter</artifactId>
         </dependency>
         <dependency>
-            <groupId>edu.gemini.util.osgi</groupId>
-            <artifactId>osgi</artifactId>
+            <groupId>edu.gemini.ocs</groupId>
+            <artifactId>edu-gemini-util-osgi_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/gmp-services/pom.xml
+++ b/gmp-services/pom.xml
@@ -33,8 +33,8 @@
             <artifactId>giapi-jms-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>edu.gemini.util.osgi</groupId>
-            <artifactId>osgi</artifactId>
+            <groupId>edu.gemini.ocs</groupId>
+            <artifactId>edu-gemini-util-osgi_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/gmp-status-simulator/pom.xml
+++ b/gmp-status-simulator/pom.xml
@@ -63,8 +63,8 @@
             <artifactId>giapi-jms-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>edu.gemini.util.osgi</groupId>
-            <artifactId>osgi</artifactId>
+            <groupId>edu.gemini.ocs</groupId>
+            <artifactId>edu-gemini-util-osgi_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/gmp-status-translator/pom.xml
+++ b/gmp-status-translator/pom.xml
@@ -54,8 +54,8 @@
             <artifactId>giapi-status-setter</artifactId>
         </dependency>
         <dependency>
-            <groupId>edu.gemini.util.osgi</groupId>
-            <artifactId>osgi</artifactId>
+            <groupId>edu.gemini.ocs</groupId>
+            <artifactId>edu-gemini-util-osgi_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/gmp-tcs-context/pom.xml
+++ b/gmp-tcs-context/pom.xml
@@ -37,8 +37,8 @@
             <artifactId>giapi-jms-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>edu.gemini.util.osgi</groupId>
-            <artifactId>osgi</artifactId>
+            <groupId>edu.gemini.ocs</groupId>
+            <artifactId>edu-gemini-util-osgi_2.13</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -805,9 +805,9 @@
             </dependency>
 
             <dependency>
-                <groupId>edu.gemini.util.osgi</groupId>
-                <artifactId>osgi</artifactId>
-                <version>0.0.1</version>
+                <groupId>edu.gemini.ocs</groupId>
+                <artifactId>edu-gemini-util-osgi_2.13</artifactId>
+                <version>2021101.1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
This is a fix for subtle bug that would not allow commands to be processed.

The module that handles commands on the gmp side `gmp-command-jms-bridge` uses an ancient osgi utility library that was compiled for (I think) 2.11

The code would compile but it would try to load a class `scala.Serializable` during runtime via OSGi class loading.

This fails as that class was deprecated on scala 2.13

The fix as to rebuild the library on the ocs for 2.113 and export it to our repo.

On the gmp side we just need to refer to the new library
