### PR TITLE
Fixed bin permission and gmp-server-ctl script improved with the JAVA…

### DIFF
--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -12,7 +12,6 @@
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
             <outputDirectory>/bin</outputDirectory>
-            <fileMode>0644</fileMode>
             <includes>
                 <include>org.ops4j.pax.runner:*</include>
             </includes>
@@ -79,25 +78,23 @@
         </fileSet>
         <fileSet>
             <directory>src/main/etc/bin</directory>
-            <fileMode>0755</fileMode>
             <outputDirectory>/bin</outputDirectory>
             <filtered>true</filtered>
-            <includes>
+	    <includes>
                 <include>start.sh</include>
-                <include>gmp-server-ctl.sh</include>
+		<include>gmp-server-ctl.sh</include>
                 <include>gmp-server</include>
             </includes>
+            <fileMode>0755</fileMode>
         </fileSet>
         <!-- Copy startup scripts of any project specific config -->
         <fileSet>
             <directory>../instances/${gmp.instance}/src/main/etc/bin</directory>
             <outputDirectory>/bin</outputDirectory>
             <filtered>true</filtered>
-            <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
             <directory>../giapi-tester/src/main/etc/bin</directory>
-            <fileMode>0755</fileMode>
             <outputDirectory>/bin</outputDirectory>
             <includes>
                 <include>giapi-tester.sh</include>
@@ -141,7 +138,6 @@
         <fileSet>
             <directory>src/main/doc</directory>
             <outputDirectory>/</outputDirectory>
-            <fileMode>0644</fileMode>
             <filtered>true</filtered>
             <includes>
                 <include>*.txt</include>
@@ -150,7 +146,6 @@
         <fileSet>
             <directory>src/main/doc</directory>
             <outputDirectory>/</outputDirectory>
-            <fileMode>0644</fileMode>
             <filtered>true</filtered>
             <includes>
                 <include>README</include>

--- a/distribution/src/main/etc/bin/gmp-server-ctl.sh
+++ b/distribution/src/main/etc/bin/gmp-server-ctl.sh
@@ -13,7 +13,11 @@ PAX_RUNNER_VERSION=${pax-runner.version}
 GMP_VERSION=${gmp.version}
 
 # Overrides locally JAVA_HOME to use java 8
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+if [ -z ${JAVA_HOME:-} ]; then
+   export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+   echo "Using $JAVA_HOME for default: $JAVA_HOME"
+fi
+
 JAVA8=$JAVA_HOME/bin/java
 #
 # Confirm that java is available
@@ -22,7 +26,7 @@ which $JAVA8 > /dev/null || { echo "Need java in PATH to run"; exit 1; }
 # Verify existing variables
 if [ -z ${GMP_ROOT:-} ]; then
     tmp=`pwd`
-    GMP_ROOT="${tmp%/*}"
+    GMP_ROOT="${tmp%/bin*}"
     echo "GMP_ROOT not set. Using $GMP_ROOT"
 fi
 if ! [ -d $GMP_ROOT ]; then


### PR DESCRIPTION
This version solves the problem of permissions in the bin directory when creating the tar.gz. It also improves the gmp-server.ctl. 