### PR TITLE
Not open and close the loop in slow guiding

### DIFF
--- a/gmp-tcs-offset/src/main/java/edu/gemini/aspen/gmp/tcsoffset/jms/TcsOffsetRequestListener.java
+++ b/gmp-tcs-offset/src/main/java/edu/gemini/aspen/gmp/tcsoffset/jms/TcsOffsetRequestListener.java
@@ -147,11 +147,11 @@ public class TcsOffsetRequestListener implements MessageListener {
         double pVal = (limitP) ? p : 0;
         double qVal = (limitQ) ? q : 0;
         try {
-            _epicsTcsOffsetIOC.setTcsOffset(pVal,qVal);
+            _epicsTcsOffsetIOC.setTcsOffset(pVal,qVal, offsetType);
         } catch (TcsOffsetException e) {
             e.printStackTrace();
             if (e.getTypeError() == TcsOffsetException.Error.TCS_WAS_REBOOTED)
-                _epicsTcsOffsetIOC.setTcsOffset(p,q);
+                _epicsTcsOffsetIOC.setTcsOffset(p,q, offsetType);
             else
                 throw e;
         }

--- a/gmp-tcs-offset/src/main/java/edu/gemini/aspen/gmp/tcsoffset/model/TcsOffsetIOC.java
+++ b/gmp-tcs-offset/src/main/java/edu/gemini/aspen/gmp/tcsoffset/model/TcsOffsetIOC.java
@@ -12,6 +12,6 @@ import javax.jms.Destination;
  */
 public interface TcsOffsetIOC {
 
-    void setTcsOffset(double p, double q) throws TcsOffsetException;
+    void setTcsOffset(double p, double q, OffsetType offsetType) throws TcsOffsetException;
 
 }


### PR DESCRIPTION
This new PR handles how to apply an offset in slow guiding correction. Basically, it does not open the loops and applies the offset. 