### PR TITLE
Gmp 14 - address issues with ActionManagerImpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2018,3 +2018,8 @@ releases.properties
 /src/main/config/services/target
 
 .idea
+.direnv/
+.metals/
+.pax/
+
+.bloop/

--- a/.gitignore
+++ b/.gitignore
@@ -2024,3 +2024,4 @@ releases.properties
 
 .bloop/
 /nb-configuration.xml
+/distribution/nb-configuration.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2023,3 +2023,4 @@ releases.properties
 .pax/
 
 .bloop/
+/nb-configuration.xml

--- a/cas/pom.xml
+++ b/cas/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.cas</groupId>
     <artifactId>cas</artifactId>
-    <version>0.3.16-SNAPSHOT</version>
+    <version>0.3.16</version>
 
     <name>Channel Access Server</name>
     <description>Channel Access Server</description>

--- a/casdb/pom.xml
+++ b/casdb/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.cas</groupId>
     <artifactId>casdb</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>Channel Access Server Database</name>
     <description>Channel Access Server Database Standalone</description>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>gmp-server</artifactId>
-    <version>14.5.9</version>
+    <version>14.5.10</version>
 
     <packaging>pom</packaging>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>edu.gemini.aspen</groupId>
         <artifactId>giapi-osgi</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <artifactId>gmp-server</artifactId>
-    <version>14.5.9-SNAPSHOT</version>
+    <version>14.5.9</version>
 
     <packaging>pom</packaging>
 

--- a/epics-api/pom.xml
+++ b/epics-api/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.epics</groupId>
     <artifactId>epics-api</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>EPICS API</name>
     <description>EPICS interfaces used by cas and epic-service.</description>

--- a/epics-heartbeat/pom.xml
+++ b/epics-heartbeat/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>epics-heartbeat</artifactId>
-    <version>0.4.16-SNAPSHOT</version>
+    <version>0.4.16</version>
 
     <name>EPICS Heartbeat</name>
     <description>EPICS Heartbeat</description>

--- a/epics-service/pom.xml
+++ b/epics-service/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.epics</groupId>
     <artifactId>epics-service</artifactId>
-    <version>0.26-SNAPSHOT</version>
+    <version>0.26</version>
 
     <name>EPICS Service</name>
     <description>Easy interface to watch EPICS values.</description>

--- a/gds-actors-composer/pom.xml
+++ b/gds-actors-composer/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-actors-composer</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>GDS Actors Composer</name>
     <description>An engine to compose values that are included in observations</description>

--- a/gds-api/pom.xml
+++ b/gds-api/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-api</artifactId>
-    <version>0.6.19-SNAPSHOT</version>
+    <version>0.6.19</version>
 
     <name>GDS API</name>
     <description>The module contains common classes and interfaces</description>

--- a/gds-config-validator/pom.xml
+++ b/gds-config-validator/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-config-validator</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>GDS Config Validator</name>
 

--- a/gds-constant-actors/pom.xml
+++ b/gds-constant-actors/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-constant-actors</artifactId>
-    <version>0.2.25-SNAPSHOT</version>
+    <version>0.2.25</version>
 
     <name>GDS Constant</name>
     <description>The module is capable of using contant values as keywords values in FITS files</description>

--- a/gds-datalabel-provider/pom.xml
+++ b/gds-datalabel-provider/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-datalabel-provider</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>GDS DataLabel Provider</name>
     <description>The module provides a service to get data labels</description>

--- a/gds-epics-actors/pom.xml
+++ b/gds-epics-actors/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-epics-actors</artifactId>
-    <version>0.1.37-SNAPSHOT</version>
+    <version>0.1.37</version>
 
     <name>GDS EPICS</name>
     <description>The module is capable of retrieving values from EPICS to use them in GDS</description>

--- a/gds-fits-checker/pom.xml
+++ b/gds-fits-checker/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-fits-checker</artifactId>
-    <version>0.4.20-SNAPSHOT</version>
+    <version>0.4.20</version>
 
     <name>GDS FITS Checker</name>
     <description>The module contains components that check the FITS file written by the instrument.

--- a/gds-fits-updater/pom.xml
+++ b/gds-fits-updater/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-fits-updater</artifactId>
-    <version>0.4.21-SNAPSHOT</version>
+    <version>0.4.21</version>
 
     <name>GDS FITS Updater</name>
     <description>API to add FITS keywords to files</description>

--- a/gds-health/pom.xml
+++ b/gds-health/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-health</artifactId>
-    <version>0.5.16-SNAPSHOT</version>
+    <version>0.5.16</version>
 
     <name>GDS Health</name>
     <description>The module provides the overall health of the GDS</description>

--- a/gds-instrument-status-actors/pom.xml
+++ b/gds-instrument-status-actors/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-instrument-status-actors</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>GDS Instrument Status</name>
     <description>The module is capable of retrieving values from Instrument Status to use them in GDS</description>

--- a/gds-keywords-database/pom.xml
+++ b/gds-keywords-database/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-keywords-database</artifactId>
-    <version>0.2.36-SNAPSHOT</version>
+    <version>0.2.36</version>
 
     <name>GDS Keywords Database</name>
     <description>An in-memory database to store Observation Values</description>

--- a/gds-observation-state-publisher/pom.xml
+++ b/gds-observation-state-publisher/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-observation-state-publisher</artifactId>
-    <version>0.4.25-SNAPSHOT</version>
+    <version>0.4.25</version>
 
     <name>GDS Observation State Publisher</name>
     <description>The module provides information about the latests observations processed by the GDS</description>

--- a/gds-obsevent-handler/pom.xml
+++ b/gds-obsevent-handler/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-obsevent-handler</artifactId>
-    <version>0.4.19-SNAPSHOT</version>
+    <version>0.4.19</version>
 
     <name>GDS Observation Event Handler</name>
     <description>An engine to compose values that are included in observations</description>

--- a/gds-performance-monitoring/pom.xml
+++ b/gds-performance-monitoring/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-performance-monitoring</artifactId>
-    <version>0.2.33-SNAPSHOT</version>
+    <version>0.2.33</version>
 
     <name>GDS Performance Monitoring</name>
     <description>The module provides a service to publish/retrieve performance stats</description>

--- a/gds-postprocessing-policy/pom.xml
+++ b/gds-postprocessing-policy/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-postprocessing-policy</artifactId>
-    <version>0.4.17-SNAPSHOT</version>
+    <version>0.4.17</version>
 
     <name>GDS Post Processing Policies</name>
     <description>The module defines a set of classes that con implement different post processing policies after an observation is completed</description>

--- a/gds-properties-actors/pom.xml
+++ b/gds-properties-actors/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-properties-actors</artifactId>
-    <version>0.1.31-SNAPSHOT</version>
+    <version>0.1.31</version>
 
     <name>GDS Properties</name>
     <description>The module is capable of retrieving system or java properties to use them in GDS</description>

--- a/gds-seqexec-actors/pom.xml
+++ b/gds-seqexec-actors/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-seqexec-actors</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>GDS SEQEXEC</name>
     <description>The module is capable of retrieving the FITS keywords sent by the seqexec to use them in GDS

--- a/gds-static-header-receiver/pom.xml
+++ b/gds-static-header-receiver/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gds</groupId>
     <artifactId>gds-static-header-receiver</artifactId>
-    <version>0.2.35-SNAPSHOT</version>
+    <version>0.2.35</version>
 
     <name>GDS Static Header Receiver</name>
     <description>The module provides a service for the seqexec to publish its FITS headers</description>

--- a/giapi-clients-lib/pom.xml
+++ b/giapi-clients-lib/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.giapi.clients</groupId>
     <artifactId>giapi-clients-lib</artifactId>
-    <version>1.0.15-SNAPSHOT</version>
+    <version>1.0.15</version>
 
     <name>GIAPI Clients library</name>
     <description>The module contains common classes and interfaces for giapi clients</description>

--- a/giapi-fileevent-handler/pom.xml
+++ b/giapi-fileevent-handler/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-fileevent-handler</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
     <description>File Event Handlers for testing purpose.</description>
 
     <name>GIAPI File Event Handler Demo</name>

--- a/giapi-fileevents/pom.xml
+++ b/giapi-fileevents/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-fileevents</artifactId>
-    <version>0.2.36-SNAPSHOT</version>
+    <version>0.2.36</version>
 
     <name>GIAPI File Event Monitor</name>
     <description>Monitor service to listen for File Events over JMS and dispatch them to interested clients.

--- a/giapi-jms-util/pom.xml
+++ b/giapi-jms-util/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-jms-util</artifactId>
-    <version>0.4.16-SNAPSHOT</version>
+    <version>0.4.16</version>
 
     <name>GIAPI JMS Util</name>
     <description>Utility classes to convert GIAPI data using JMS</description>

--- a/giapi-obsevents/pom.xml
+++ b/giapi-obsevents/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-obsevents</artifactId>
-    <version>0.2.36-SNAPSHOT</version>
+    <version>0.2.36</version>
 
     <name>GIAPI Observation Event Monitor</name>
     <description>Monitor service to listen for Observation Events and dispatch it to interested clients.</description>

--- a/giapi-status-dispatcher/pom.xml
+++ b/giapi-status-dispatcher/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-status-dispatcher</artifactId>
-    <version>0.3.16-SNAPSHOT</version>
+    <version>0.3.16</version>
 
     <name>GIAPI Status Dispatcher</name>
     <description>Status Dispatcher</description>

--- a/giapi-status-service/pom.xml
+++ b/giapi-status-service/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-status-service</artifactId>
-    <version>0.5.16-SNAPSHOT</version>
+    <version>0.5.16</version>
 
     <name>GIAPI Status Service</name>
     <description>The Status Service listen for Status Items via JMS and notifies registered Status Handlers

--- a/giapi-status-setter/pom.xml
+++ b/giapi-status-setter/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.giapi</groupId>
     <artifactId>giapi-status-setter</artifactId>
-    <version>0.1.16-SNAPSHOT</version>
+    <version>0.1.16</version>
 
     <name>GIAPI Status Setter</name>
     <description>Utility classes to set status items using JMS</description>

--- a/giapi-test-support/pom.xml
+++ b/giapi-test-support/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-test-support</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <description>The GIAPI test support classes</description>
 

--- a/giapi-tester/pom.xml
+++ b/giapi-tester/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-tester</artifactId>
-    <version>0.1.38-SNAPSHOT</version>
+    <version>0.1.38</version>
 
     <name>GIAPI Tester</name>
 

--- a/giapi/pom.xml
+++ b/giapi/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi</artifactId>
-    <version>1.0.34-SNAPSHOT</version>
+    <version>1.0.34</version>
     <description>The GIAPI core interfaces</description>
 
     <name>GIAPI</name>

--- a/gmp-command-handlers/pom.xml
+++ b/gmp-command-handlers/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-command-handlers</artifactId>
-    <version>1.0.33-SNAPSHOT</version>
+    <version>1.0.33</version>
 
     <name>GMP Sequence Commands Handlers</name>
     <description>Service giving information about available command handlers</description>

--- a/gmp-commands-jms-bridge/pom.xml
+++ b/gmp-commands-jms-bridge/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-commands-jms-bridge</artifactId>
-    <version>0.5.16-SNAPSHOT</version>
+    <version>0.5.16</version>
 
     <name>GMP Commands JMS Bridge</name>
 

--- a/gmp-commands-jms-client/pom.xml
+++ b/gmp-commands-jms-client/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-commands-jms-client</artifactId>
-    <version>0.1.36-SNAPSHOT</version>
+    <version>0.1.36</version>
 
     <name>GMP Commands JMS Client</name>
 

--- a/gmp-commands-records/pom.xml
+++ b/gmp-commands-records/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.gmp</groupId>
     <artifactId>gmp-commands-records</artifactId>
-    <version>0.6.14-SNAPSHOT</version>
+    <version>0.6.14</version>
 
     <name>GMP Commands Records</name>
     <description>GMP Commands Records</description>

--- a/gmp-commands/nb-configuration.xml
+++ b/gmp-commands/nb-configuration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
+    </properties>
+</project-shared-configuration>

--- a/gmp-commands/pom.xml
+++ b/gmp-commands/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-commands</artifactId>
-    <version>1.1.16-SNAPSHOT</version>
+    <version>1.1.17</version>
 
     <name>GMP Sequence Commands Service</name>
     <description>Sequence Command Processor service</description>

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutor.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutor.java
@@ -43,14 +43,14 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
             return HandlerResponse.createError(ERROR_MSG);
         } else {
             List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
-            LOG.fine("Execute ActionID:" + action.getId() + " got " + applyHandlers.size() + 
+            LOG.fine("Execute action ID " + action.getId() + " got " + applyHandlers.size() + 
                     " Apply Handlers (" + applyHandlers + ")");         
 
             int expectedResponses = countExpectedResponses(config, ConfigPath.EMPTY_PATH, applyHandlers);
-            LOG.fine("Action ActionID:" + action.getId() + " expects " + expectedResponses + " responses");
+            LOG.fine("Action action ID " + action.getId() + " expects " + expectedResponses + " responses");
 
             if (!canBeFullyHandled(config, applyHandlers)) {
-              LOG.severe("Action ActionID:" + action.getId() + " cannot be fully handled, there are missing handlers. return NOANSWER");
+              LOG.severe("Action action ID " + action.getId() + " cannot be fully handled, there are missing handlers. return NOANSWER");
               
               return HandlerResponse.NOANSWER;
             }
@@ -151,7 +151,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
         Set<ConfigPath> configPathSet = navigator.getChildPaths(path);
 
         if (configPathSet.isEmpty()) {
-            LOG.info("Action ActionID:" + action.getId() + " has empty path set, respond NOANSWER");
+            LOG.info("Action action ID " + action.getId() + " has empty path set, respond NOANSWER");
             return HandlerResponse.NOANSWER;
         }
 
@@ -165,7 +165,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
 
             HandlerResponse response = null;
             if (applyHandlers.isEmpty() || applyHandlers.contains(cp)) {
-                LOG.info("Attempt to send apply for configuration " + c + " with ActionID:" + action.getId() + " and timeout " 
+                LOG.info("Attempt to send apply for configuration " + c + " with action ID " + action.getId() + " and timeout " 
                         + action.getTimeout());
                 ActionMessage am = _actionMessageBuilder.buildActionMessage(action, cp);
                 Stopwatch s = Stopwatch.createStarted();
@@ -174,7 +174,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
 
                 // if the response is COMPLETED remove waiting for a response
                 if (response == HandlerResponse.COMPLETED) {
-                    LOG.info("Action immediately completed ActionID:" + action.getId());
+                    LOG.info("Action immediately completed action ID " + action.getId());
                     _actionManager.decreaseRequiredResponses(action);
                 }
 

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutor.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutor.java
@@ -43,14 +43,14 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
             return HandlerResponse.createError(ERROR_MSG);
         } else {
             List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
-            LOG.fine("Execute action " + action.getId() + " got " + applyHandlers.size() + 
+            LOG.fine("Execute ActionID:" + action.getId() + " got " + applyHandlers.size() + 
                     " Apply Handlers (" + applyHandlers + ")");         
 
             int expectedResponses = countExpectedResponses(config, ConfigPath.EMPTY_PATH, applyHandlers);
-            LOG.fine("Action " + action + " expects " + expectedResponses + " responses");
+            LOG.fine("Action ActionID:" + action.getId() + " expects " + expectedResponses + " responses");
 
             if (!canBeFullyHandled(config, applyHandlers)) {
-              LOG.severe("Action " + action + " cannot be fully handled, there are missing handlers. return NOANSWER");
+              LOG.severe("Action ActionID:" + action.getId() + " cannot be fully handled, there are missing handlers. return NOANSWER");
               
               return HandlerResponse.NOANSWER;
             }
@@ -151,7 +151,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
         Set<ConfigPath> configPathSet = navigator.getChildPaths(path);
 
         if (configPathSet.isEmpty()) {
-            LOG.info("Action " + action + " has empty path set, respond NOANSWER");
+            LOG.info("Action ActionID:" + action.getId() + " has empty path set, respond NOANSWER");
             return HandlerResponse.NOANSWER;
         }
 
@@ -165,7 +165,8 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
 
             HandlerResponse response = null;
             if (applyHandlers.isEmpty() || applyHandlers.contains(cp)) {
-                LOG.info("Attempt to send apply for configuration " + c + " with id " + action.getId() + " and timeout " + action.getTimeout());
+                LOG.info("Attempt to send apply for configuration " + c + " with ActionID:" + action.getId() + " and timeout " 
+                        + action.getTimeout());
                 ActionMessage am = _actionMessageBuilder.buildActionMessage(action, cp);
                 Stopwatch s = Stopwatch.createStarted();
                 response = sender.send(am, action.getTimeout());
@@ -173,7 +174,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
 
                 // if the response is COMPLETED remove waiting for a response
                 if (response == HandlerResponse.COMPLETED) {
-                    LOG.info("Action immediately completed: " + action.getId());
+                    LOG.info("Action immediately completed ActionID:" + action.getId());
                     _actionManager.decreaseRequiredResponses(action);
                 }
 

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutor.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutor.java
@@ -42,11 +42,14 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
         if (config.isEmpty()) {
             return HandlerResponse.createError(ERROR_MSG);
         } else {
+            List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
+            LOG.fine("Execute action " + action.getId() + " got " + applyHandlers.size() + 
+                    " Apply Handlers (" + applyHandlers + ")");         
 
-            int expectedResponses = countExpectedResponses(config, ConfigPath.EMPTY_PATH);
+            int expectedResponses = countExpectedResponses(config, ConfigPath.EMPTY_PATH, applyHandlers);
             LOG.fine("Action " + action + " expects " + expectedResponses + " responses");
 
-            if (!canBeFullyHandled(config)) {
+            if (!canBeFullyHandled(config, applyHandlers)) {
               LOG.severe("Action " + action + " cannot be fully handled, there are missing handlers. return NOANSWER");
               
               return HandlerResponse.NOANSWER;
@@ -54,27 +57,28 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
             for (int i = 0; i < expectedResponses; i++) {
                 _actionManager.increaseRequiredResponses(action);
             }
-
-            return getResponse(action, config, ConfigPath.EMPTY_PATH, sender);
+            
+             return getResponse(action, config, ConfigPath.EMPTY_PATH, sender, applyHandlers);
         }
     }
 
-    protected boolean canBeFullyHandled(Configuration config) {
-       return _canBeFullyHandled(false, config, ConfigPath.EMPTY_PATH);
+    protected boolean canBeFullyHandled(Configuration config, List<ConfigPath> applyHandlers) {
+       return _canBeFullyHandled(false, config, ConfigPath.EMPTY_PATH, applyHandlers);
     }
 
-    private boolean _canBeFullyHandled(boolean current, Configuration config, ConfigPath path) {
+    private boolean _canBeFullyHandled(boolean current, Configuration config, ConfigPath path, List<ConfigPath> applyHandlers) {
 
         ConfigPathNavigator navigator = new ConfigPathNavigator(config);
         Set<ConfigPath> configPathSet = navigator.getChildPaths(path);
         boolean ct = current;
 
         if (configPathSet.isEmpty()) {
+            LOG.warning("Could not find an Apply Handler for " + path);
             return false;
         }
 
         //this analyzer will get the result answer from this part of the configuration
-        List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
+        //List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
         if (applyHandlers.isEmpty()) return false;
 
         for (ConfigPath cp : configPathSet) {
@@ -85,28 +89,29 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
                 current = true;
             } else {
                 // If there are no handlers registered go straight to the sub-handlers
-                return _canBeFullyHandled(current, c, cp);
+                return _canBeFullyHandled(current, c, cp, applyHandlers);
             }
         }
         return current;
     }
 
-    protected int countExpectedResponses(Configuration config, ConfigPath path) {
-       return _countExpectedResponses(0, config, path);
+    protected int countExpectedResponses(Configuration config, ConfigPath path, List<ConfigPath> applyHandlers) {
+       return _countExpectedResponses(0, config, path, applyHandlers);
     }
 
-    private int _countExpectedResponses(int counter, Configuration config, ConfigPath path) {
+    private int _countExpectedResponses(int counter, Configuration config, ConfigPath path, List<ConfigPath> applyHandlers) {
 
         ConfigPathNavigator navigator = new ConfigPathNavigator(config);
         Set<ConfigPath> configPathSet = navigator.getChildPaths(path);
         int ct = counter;
 
         if (configPathSet.isEmpty()) {
+            LOG.warning("Could not find an Apply Handler for " + path);
             return 1;
         }
 
         //this analyzer will get the result answer from this part of the configuration
-        List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
+        //List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
 
         for (ConfigPath cp : configPathSet) {
             //get the sub-configuration
@@ -116,7 +121,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
                 ct = ct + 1;
             } else {
                 // If there are no handlers registered go straight to the sub-handlers
-                ct = _countExpectedResponses(ct, c, cp);
+                ct = _countExpectedResponses(ct, c, cp, applyHandlers);
             }
         }
         return ct;
@@ -131,13 +136,16 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
      * @param path   current path level in the configuration
      * @param sender A Map Sender object that will send this message and will
      *               get an answer.
+     * @param applyHandlers List of handlers that have been registered
+     * 
      * @return a HandlerResponse representing the result of sending the
      *         configuration. If there are no handlers for this configuration,
      *         this call will try to decompose the configuration in smaller units
      *         in an attempt to see if it can be handled by other handlers.
      */
     private HandlerResponse getResponse(Action action, Configuration config,
-                                        ConfigPath path, ActionSender sender) {
+                                        ConfigPath path, ActionSender sender,
+                                        List<ConfigPath> applyHandlers) {
 
         ConfigPathNavigator navigator = new ConfigPathNavigator(config);
         Set<ConfigPath> configPathSet = navigator.getChildPaths(path);
@@ -149,7 +157,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
 
         //this analyzer will get the result answer from this part of the configuration
         HandlerResponseAnalyzer analyzer = new HandlerResponseAnalyzer();
-        List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
+        //List<ConfigPath> applyHandlers = commandHandlers.getApplyHandlers();
 
         for (ConfigPath cp : configPathSet) {
             //get the sub-configuration
@@ -172,7 +180,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
                 //if there are no handlers, recursively decompose this config in
                 //smaller units if possible, and return the answer.
                 if (response == HandlerResponse.NOANSWER) {
-                    response = getResponse(action, c, cp, sender);
+                    response = getResponse(action, c, cp, sender, applyHandlers);
                 }
 
                 //if the answer is still NOANSWER, return immediately, there is no one
@@ -183,7 +191,7 @@ public class ApplySenderExecutor implements SequenceCommandExecutor {
             } else {
                 LOG.finer("No handler for " + cp + " go to next sub-level..");
                 // If there are no handlers registered go straight to the sub-handlers
-                response = getResponse(action, c, cp, sender);
+                response = getResponse(action, c, cp, sender, applyHandlers);
             }
             analyzer.addResponse(response);
         }

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/SequenceCommandExecutorStrategy.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/executors/SequenceCommandExecutorStrategy.java
@@ -74,7 +74,7 @@ public class SequenceCommandExecutorStrategy implements SequenceCommandExecutor 
             LOG.warning("Exception publishing command status " + e.getMessage());
         }
         lastAction = action;
-        LOG.info("About to execute action " + action);
+        LOG.info("About to execute action ID " + action.getId());
         return findCommandExecutor(command.getSequenceCommand()).execute(action, sender);
     }
 

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/ActionManagerImpl.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/ActionManagerImpl.java
@@ -157,7 +157,8 @@ public class ActionManagerImpl implements ActionManager {
                         //store this response to combine it with the other answers we might receive for the same action
                         _handlerResponseTracker.storeResponse(action, response);
                         if (_handlerResponseTracker.isComplete(action)) {
-                            LOG.info("Updating clients with action " + action + " response " + _handlerResponseTracker.getResponse(action));
+                            LOG.info("Updating clients with ActionID:" + action.getId() + " response " 
+                                    + _handlerResponseTracker.getResponse(action));
                             action.sendResponseToListeners(_handlerResponseTracker.getResponse(action));
                             //remove the action from the list of tracked actions
                             _handlerResponseTracker.removeTrackedAction(action);
@@ -165,12 +166,12 @@ public class ActionManagerImpl implements ActionManager {
                             //now, remove the element from the list
                             _actionList.remove(action);
                         } else {
-                           LOG.info("Received update for action " + action + " response "
+                           LOG.info("Received update for ActionID:" + action.getId() + " response "
                                   + response + ". Waiting for " + _handlerResponseTracker.getPendingResponses(action)
                                   + " other parts of the action to complete...");
                             //in this case, the loop is aborted, since this action is not completed yet,
                             //so we have to keep waiting.
-                            action = null;
+                            //action = null;
                         }
                     }
                 } finally {
@@ -222,13 +223,13 @@ public class ActionManagerImpl implements ActionManager {
 
     @Override
     public void registerAction(Action action) {
-        LOG.fine("Start monitoring progress for Action " + action);
+        LOG.fine("Start monitoring progress for ActionID:" + action.getId());
         _actionList.add(action);
     }
 
     @Override
     public void unregisterAction(Action action) {
-        LOG.fine("Stopped monitoring progress for Action " + action + ". Action Completed Immediately");
+        LOG.fine("Stopped monitoring progress for ActionID: " + action.getId() + ". Action Completed Immediately");
         _actionList.remove(action);
     }
 

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/ActionManagerImpl.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/ActionManagerImpl.java
@@ -165,8 +165,9 @@ public class ActionManagerImpl implements ActionManager {
                             //now, remove the element from the list
                             _actionList.remove(action);
                         } else {
-                            LOG.info("Received update for action " + action + " response " +
-                                    response + ". Waiting for the other parts of the action to complete...");
+                           LOG.info("Received update for action " + action + " response "
+                                  + response + ". Waiting for " + _handlerResponseTracker.getPendingResponses(action)
+                                  + " other parts of the action to complete...");
                             //in this case, the loop is aborted, since this action is not completed yet,
                             //so we have to keep waiting.
                             action = null;

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/ActionManagerImpl.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/ActionManagerImpl.java
@@ -157,7 +157,7 @@ public class ActionManagerImpl implements ActionManager {
                         //store this response to combine it with the other answers we might receive for the same action
                         _handlerResponseTracker.storeResponse(action, response);
                         if (_handlerResponseTracker.isComplete(action)) {
-                            LOG.info("Updating clients with ActionID:" + action.getId() + " response " 
+                            LOG.info("Updating clients with action ID " + action.getId() + " response " 
                                     + _handlerResponseTracker.getResponse(action));
                             action.sendResponseToListeners(_handlerResponseTracker.getResponse(action));
                             //remove the action from the list of tracked actions
@@ -166,7 +166,7 @@ public class ActionManagerImpl implements ActionManager {
                             //now, remove the element from the list
                             _actionList.remove(action);
                         } else {
-                           LOG.info("Received update for ActionID:" + action.getId() + " response "
+                           LOG.info("Received update for action ID " + action.getId() + " response "
                                   + response + ". Waiting for " + _handlerResponseTracker.getPendingResponses(action)
                                   + " other parts of the action to complete...");
                             //in this case, the loop is aborted, since this action is not completed yet,
@@ -223,13 +223,13 @@ public class ActionManagerImpl implements ActionManager {
 
     @Override
     public void registerAction(Action action) {
-        LOG.fine("Start monitoring progress for ActionID:" + action.getId());
+        LOG.fine("Start monitoring progress for action ID " + action.getId());
         _actionList.add(action);
     }
 
     @Override
     public void unregisterAction(Action action) {
-        LOG.fine("Stopped monitoring progress for ActionID: " + action.getId() + ". Action Completed Immediately");
+        LOG.fine("Stopped monitoring progress for action ID  " + action.getId() + ". Action Completed Immediately");
         _actionList.remove(action);
     }
 

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/CommandSenderImpl.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/CommandSenderImpl.java
@@ -78,7 +78,7 @@ public class CommandSenderImpl implements CommandSender {
         _manager.registerAction(action);
 
         Stopwatch stopwatch = Stopwatch.createStarted();
-        LOG.fine("About to execute apply for ActionID:" + action.getId());
+        LOG.fine("About to execute apply for action " + action);
         HandlerResponse response = _executor.execute(action, _sender);
 
         //The only response that indicates actions have started is
@@ -86,10 +86,10 @@ public class CommandSenderImpl implements CommandSender {
         //that must be completed at a later time, therefore the
         //Completion listener is ignored in this case. See GIAPI design
         //and use, section 10.6
-        LOG.info("Response for ActionID:" + action.getId() + " arrived: " + response + " in " + 
+        LOG.info("Response for action ID " + action.getId() + " arrived: " + response + " in " + 
                 stopwatch.stop().elapsed(TimeUnit.MILLISECONDS) + " [ms]");
         if (response != null) {
-            LOG.fine("Got response " + response + " for ActionID:" + action.getId());
+            LOG.fine("Got response " + response + " for action ID " + action.getId());
             if (response.getResponse() == HandlerResponse.Response.STARTED) {
                 //now, it is possible the action has completed _while_ we were
                 //here.... let's take care of that case and if so, use the
@@ -103,7 +103,7 @@ public class CommandSenderImpl implements CommandSender {
                 try {
                     if (decoratorListener.getResponse() != null) {
                         response = decoratorListener.getResponse();
-                        LOG.fine("Got response " + response + " for ActionID:" + action.getId());
+                        LOG.fine("Got response " + response + " for action ID " + action.getId());
                         //this action is no longer valid.
                         _manager.unregisterAction(action);
                     }

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/CommandSenderImpl.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/CommandSenderImpl.java
@@ -78,7 +78,7 @@ public class CommandSenderImpl implements CommandSender {
         _manager.registerAction(action);
 
         Stopwatch stopwatch = Stopwatch.createStarted();
-        LOG.fine("About to execute apply " + action);
+        LOG.fine("About to execute apply for ActionID:" + action.getId());
         HandlerResponse response = _executor.execute(action, _sender);
 
         //The only response that indicates actions have started is
@@ -86,9 +86,10 @@ public class CommandSenderImpl implements CommandSender {
         //that must be completed at a later time, therefore the
         //Completion listener is ignored in this case. See GIAPI design
         //and use, section 10.6
-        LOG.info("Response for " + action + " arrived: " + response + " in " + stopwatch.stop().elapsed(TimeUnit.MILLISECONDS) + " [ms]");
+        LOG.info("Response for ActionID:" + action.getId() + " arrived: " + response + " in " + 
+                stopwatch.stop().elapsed(TimeUnit.MILLISECONDS) + " [ms]");
         if (response != null) {
-            LOG.fine("Got response " + response + " for action " + action);
+            LOG.fine("Got response " + response + " for ActionID:" + action.getId());
             if (response.getResponse() == HandlerResponse.Response.STARTED) {
                 //now, it is possible the action has completed _while_ we were
                 //here.... let's take care of that case and if so, use the
@@ -102,7 +103,7 @@ public class CommandSenderImpl implements CommandSender {
                 try {
                     if (decoratorListener.getResponse() != null) {
                         response = decoratorListener.getResponse();
-                        LOG.fine("Got response " + response + " for action " + action);
+                        LOG.fine("Got response " + response + " for ActionID:" + action.getId());
                         //this action is no longer valid.
                         _manager.unregisterAction(action);
                     }

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/HandlerResponseTracker.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/HandlerResponseTracker.java
@@ -150,7 +150,7 @@ class HandlerResponseTracker {
         if (responseHolder != null) {
             return responseHolder.getResponse();
         }
-        LOG.warning("We are not tracking progress for action " + action);
+        LOG.warning("We are not tracking progress for ActionID:" + action.getId());
         return null;
     }
 

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/HandlerResponseTracker.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/HandlerResponseTracker.java
@@ -150,7 +150,7 @@ class HandlerResponseTracker {
         if (responseHolder != null) {
             return responseHolder.getResponse();
         }
-        LOG.warning("We are not tracking progress for ActionID:" + action.getId());
+        LOG.warning("We are not tracking progress for action ID " + action.getId());
         return null;
     }
 

--- a/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/HandlerResponseTracker.java
+++ b/gmp-commands/src/main/java/edu/gemini/aspen/gmp/commands/model/impl/HandlerResponseTracker.java
@@ -58,6 +58,14 @@ class HandlerResponseTracker {
         }
 
         /**
+         * Return the number of pending responses
+         * @return 
+         */
+        public int getPendingResponses() {
+          return pendingResponses.get();
+        }
+        
+        /**
          * Returns a summary of the results collected.
          * @return Summary of the results collected or an error response in
          * case the required ammount of responses have not been received.
@@ -118,6 +126,16 @@ class HandlerResponseTracker {
         return responseHolder == null || responseHolder.hasNoPendingResponses();
     }
 
+   /**
+    * Return the number of pending responses
+    *
+    * @return
+    */
+    public int getPendingResponses(Action action) {
+       ResponseHolder responseHolder = _actionResponsesMap.get(action);
+       return responseHolder.getPendingResponses();
+    }
+        
 
     /**
      * Get the response for the given action, if it has been completed

--- a/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/ApplyExecutorTest.java
+++ b/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/ApplyExecutorTest.java
@@ -60,9 +60,9 @@ public class ApplyExecutorTest {
                 .withPath(configPath("ghost:dc:red.ccf"), "4")
                 .withPath(configPath("ghost:cc:slu:fa1.type"), "SET")
                 .build();
-
-        assert (_executor.canBeFullyHandled(_applyConfig1));
-        assertEquals(3, _executor.countExpectedResponses(_applyConfig1, ConfigPath.EMPTY_PATH));
+        List<ConfigPath> applyHandlers = handlers.getApplyHandlers();
+        assert (_executor.canBeFullyHandled(_applyConfig1, applyHandlers));
+        assertEquals(3, _executor.countExpectedResponses(_applyConfig1, ConfigPath.EMPTY_PATH, applyHandlers));
     }
     /**
      * Count the handlers
@@ -85,9 +85,9 @@ public class ApplyExecutorTest {
                 .withPath(configPath("X:S2:C.val2"), "xc2")
                 .withPath(configPath("X:S2:C.val3"), "xc3")
                 .build();
-
-        assert (_executor.canBeFullyHandled(_applyConfig1));
-        assertEquals(2, _executor.countExpectedResponses(_applyConfig1, ConfigPath.EMPTY_PATH));
+        List<ConfigPath> applyHandlers = handlers.getApplyHandlers();
+        assert (_executor.canBeFullyHandled(_applyConfig1, applyHandlers));
+        assertEquals(2, _executor.countExpectedResponses(_applyConfig1, ConfigPath.EMPTY_PATH, applyHandlers));
 
         Configuration _applyConfig3 = configurationBuilder()
                 .withPath(configPath("X:S1:A.val1"), "xa1")
@@ -95,8 +95,8 @@ public class ApplyExecutorTest {
                 .withPath(configPath("X:S3:C.val3"), "xc3") // This one is unhandled
                 .build();
 
-        assert (!_executor.canBeFullyHandled(_applyConfig3));
-        assertEquals(1, _executor.countExpectedResponses(_applyConfig3, ConfigPath.EMPTY_PATH));
+        assert (!_executor.canBeFullyHandled(_applyConfig3, applyHandlers));
+        assertEquals(1, _executor.countExpectedResponses(_applyConfig3, ConfigPath.EMPTY_PATH, applyHandlers));
     }
 
     /**

--- a/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutorTest.java
+++ b/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutorTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import static edu.gemini.aspen.giapi.commands.ConfigPath.configPath;
 import static edu.gemini.aspen.giapi.commands.DefaultConfiguration.configurationBuilder;
 import static edu.gemini.aspen.giapi.commands.DefaultConfiguration.emptyConfiguration;
+import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -30,11 +31,12 @@ public class ApplySenderExecutorTest {
 
     private Configuration _applyConfig;
     private ActionManagerImpl actionManager;
+    private CommandHandlers handlers;
 
     @Before
     public void setUp() {
         ActionMessageBuilder builder = mock(ActionMessageBuilder.class);
-        CommandHandlers handlers = mock(CommandHandlers.class);
+        handlers = mock(CommandHandlers.class);
 
         actionManager = new ActionManagerImpl();
         actionManager.start();
@@ -74,7 +76,8 @@ public class ApplySenderExecutorTest {
      */
     @Test
     public void testCountResponses() {
-        assertEquals(1, _executor.countExpectedResponses(_applyConfig, ConfigPath.EMPTY_PATH));
+        List<ConfigPath> applyHandlers = handlers.getApplyHandlers();
+        assertEquals(1, _executor.countExpectedResponses(_applyConfig, ConfigPath.EMPTY_PATH, applyHandlers));
     }
 
     /**

--- a/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutorWithMultipleHandlersTest.java
+++ b/gmp-commands/src/test/java/edu/gemini/aspen/gmp/commands/model/executors/ApplySenderExecutorWithMultipleHandlersTest.java
@@ -104,8 +104,9 @@ public class ApplySenderExecutorWithMultipleHandlersTest {
                 .withPath(configPath("X:S2:C.val2"), "xc2")
                 .withPath(configPath("X:S2:C.val3"), "xc3")
                 .build();
+        List<ConfigPath> applyHandlers = handlers.getApplyHandlers();
 
-        assertEquals(2, _executor.countExpectedResponses(_applyConfig1, ConfigPath.EMPTY_PATH));
+        assertEquals(2, _executor.countExpectedResponses(_applyConfig1, ConfigPath.EMPTY_PATH, applyHandlers));
 
         Configuration _applyConfig2 = configurationBuilder()
                 .withPath(configPath("X:S1:A.val1"), "xa1")
@@ -117,7 +118,7 @@ public class ApplySenderExecutorWithMultipleHandlersTest {
                 .withPath(configPath("X:S1:B.val3"), "xb3")
                 .build();
 
-        assertEquals(1, _executor.countExpectedResponses(_applyConfig2, ConfigPath.EMPTY_PATH));
+        assertEquals(1, _executor.countExpectedResponses(_applyConfig2, ConfigPath.EMPTY_PATH, applyHandlers));
 
         Configuration _applyConfig3 = configurationBuilder()
                 .withPath(configPath("X:S1:A.val1"), "xa1")
@@ -125,9 +126,9 @@ public class ApplySenderExecutorWithMultipleHandlersTest {
                 .withPath(configPath("X:S3:C.val3"), "xc3") // This one is unhandled
                 .build();
 
-        assertEquals(1, _executor.countExpectedResponses(_applyConfig3, ConfigPath.EMPTY_PATH));
+        assertEquals(1, _executor.countExpectedResponses(_applyConfig3, ConfigPath.EMPTY_PATH, applyHandlers));
 
-        assertEquals(1, _executor.countExpectedResponses(configurationBuilder().build(), ConfigPath.EMPTY_PATH));
+        assertEquals(1, _executor.countExpectedResponses(configurationBuilder().build(), ConfigPath.EMPTY_PATH, applyHandlers));
     }
 
     /**

--- a/gmp-epics-access/pom.xml
+++ b/gmp-epics-access/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-epics-access</artifactId>
-    <version>0.4.16-SNAPSHOT</version>
+    <version>0.4.16</version>
 
     <name>GMP Epics Access Service</name>
     <description>Epics Access Interface for Aspen Instruments</description>

--- a/gmp-epics-simulator/pom.xml
+++ b/gmp-epics-simulator/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-epics-simulator</artifactId>
-    <version>0.3.16-SNAPSHOT</version>
+    <version>0.3.16</version>
 
     <name>GMP Epics Simulator</name>
     <description>Simple simulator of EPICS channels for testing</description>

--- a/gmp-epics-status-service/pom.xml
+++ b/gmp-epics-status-service/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-epics-status-service</artifactId>
-    <version>0.3.16-SNAPSHOT</version>
+    <version>0.3.16</version>
 
     <name>GMP EPICS Status Service</name>
     <description>GMP EPICS Status Service</description>

--- a/gmp-epics-to-status/pom.xml
+++ b/gmp-epics-to-status/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-epics-to-status</artifactId>
-    <version>0.1.30-SNAPSHOT</version>
+    <version>0.1.30</version>
 
     <name>GMP EPICS To Status</name>
     <description>GMP EPICS To Status</description>

--- a/gmp-health/pom.xml
+++ b/gmp-health/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-health</artifactId>
-    <version>1.1.16-SNAPSHOT</version>
+    <version>1.1.16</version>
 
     <name>GMP Health</name>
     <description>GMP Health</description>

--- a/gmp-heartbeat-distributor-service/pom.xml
+++ b/gmp-heartbeat-distributor-service/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>gmp-heartbeat-distributor-service</artifactId>
-    <version>0.4.16-SNAPSHOT</version>
+    <version>0.4.16</version>
 
     <name>GMP Heartbeat Distributor Service</name>
     <description>GMP Heartbeat Distributor Service</description>

--- a/gmp-heartbeat/pom.xml
+++ b/gmp-heartbeat/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-heartbeat</artifactId>
-    <version>0.5.16-SNAPSHOT</version>
+    <version>0.5.16</version>
 
     <name>GMP Heartbeat</name>
     <description>GMP Heartbeat</description>

--- a/gmp-logging/pom.xml
+++ b/gmp-logging/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-logging</artifactId>
-    <version>0.2.36-SNAPSHOT</version>
+    <version>0.2.36</version>
 
     <name>GMP Logging Service</name>
     <description>GMP Logging Service</description>

--- a/gmp-pcs-updater/pom.xml
+++ b/gmp-pcs-updater/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-pcs-updater</artifactId>
-    <version>0.6.16-SNAPSHOT</version>
+    <version>0.6.16</version>
 
     <name>GMP PCS Updater Service</name>
     <description>PCS Updater service</description>

--- a/gmp-services/pom.xml
+++ b/gmp-services/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-services</artifactId>
-    <version>0.4.19-SNAPSHOT</version>
+    <version>0.4.19</version>
 
     <name>GMP GIAPI Services</name>
     <description>Services provided by the GMP</description>

--- a/gmp-status-gateway/pom.xml
+++ b/gmp-status-gateway/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-status-gateway</artifactId>
-    <version>0.2.36-SNAPSHOT</version>
+    <version>0.2.36</version>
 
     <name>GMP Status Gateway over JMS</name>
     <description>Allows clients to get status information received by the GMP</description>

--- a/gmp-status-simulator/pom.xml
+++ b/gmp-status-simulator/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-status-simulator</artifactId>
-    <version>0.3.16-SNAPSHOT</version>
+    <version>0.3.16</version>
 
     <name>GMP Status Simulator</name>
     <description>Simple simulator of Status items for testing</description>

--- a/gmp-status-translator/pom.xml
+++ b/gmp-status-translator/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.gmp</groupId>
     <artifactId>gmp-status-translator</artifactId>
-    <version>0.1.16-SNAPSHOT</version>
+    <version>0.1.16</version>
 
     <name>GMP Status Translator</name>
     <description>The Service can translate status items</description>

--- a/gmp-statusdb/pom.xml
+++ b/gmp-statusdb/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-statusdb</artifactId>
-    <version>0.2.16-SNAPSHOT</version>
+    <version>0.2.16</version>
 
     <name>GMP Status Database</name>
     <description>Status Database in the GMP</description>

--- a/gmp-tcs-context/pom.xml
+++ b/gmp-tcs-context/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-tcs-context</artifactId>
-    <version>0.2.36-SNAPSHOT</version>
+    <version>0.2.36</version>
 
     <name>GMP TCS Context Service</name>
     <description>TCS Context service</description>

--- a/gmp-top/pom.xml
+++ b/gmp-top/pom.xml
@@ -4,7 +4,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.gmp</groupId>
     <artifactId>gmp-top</artifactId>
-    <version>0.1.16-SNAPSHOT</version>
+    <version>0.1.16</version>
 
     <name>GMP Top</name>
     <description>GMP Top</description>

--- a/gmp-tui/pom.xml
+++ b/gmp-tui/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.gmp</groupId>
     <artifactId>gmp-tui</artifactId>
-    <version>0.5.33-SNAPSHOT</version>
+    <version>0.5.33</version>
 
     <name>GMP Text UI</name>
     <description>GMP Text User Interface</description>

--- a/gpi/gpi-observation-status/pom.xml
+++ b/gpi/gpi-observation-status/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.gpi</groupId>
     <artifactId>gpi-observation-status</artifactId>
-    <version>0.2.16-SNAPSHOT</version>
+    <version>0.2.16</version>
 
     <name>GPI Observation Status</name>
     <description>GPI Observation Status</description>

--- a/gpi/pom.xml
+++ b/gpi/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>edu.gemini.aspen</groupId>
         <artifactId>giapi-osgi</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.gpi</groupId>
     <artifactId>gpi</artifactId>
-    <version>0.1.17-SNAPSHOT</version>
+    <version>0.1.17</version>
 
     <name>GPI Modules</name>
     <description>GPI Modules</description>

--- a/instances/ghost/src/main/config/giapi-apply-config.xml
+++ b/instances/ghost/src/main/config/giapi-apply-config.xml
@@ -38,6 +38,7 @@ Warning: This is a generated file - take care if editing by hand
         <ConfigRecord name="dc:red">
             <ConfigSet name="dc:red">
                 <field>address</field>
+                <field>arc_commands_type</field>
                 <field>arg</field>
                 <field>auto_archive</field>
                 <field>auto_rdc</field>
@@ -49,6 +50,7 @@ Warning: This is a generated file - take care if editing by hand
                 <field>cmd</field>
                 <field>comment</field>
                 <field>config</field>
+                <field>controller_type</field>
                 <field>cosmic_rate</field>
                 <field>dark</field>
                 <field>data</field>
@@ -158,6 +160,7 @@ Warning: This is a generated file - take care if editing by hand
         <ConfigRecord name="dc:blue">
             <ConfigSet name="dc:blue">
                 <field>address</field>
+                <field>arc_commands_type</field>
                 <field>arg</field>
                 <field>auto_archive</field>
                 <field>auto_rdc</field>
@@ -169,6 +172,7 @@ Warning: This is a generated file - take care if editing by hand
                 <field>cmd</field>
                 <field>comment</field>
                 <field>config</field>
+                <field>controller_type</field>
                 <field>cosmic_rate</field>
                 <field>dark</field>
                 <field>data</field>
@@ -292,6 +296,7 @@ Warning: This is a generated file - take care if editing by hand
                 <field>do_save</field>
                 <field>do_test</field>
                 <field>duration</field>
+                <field>exp_meter</field>
                 <field>fitskw1</field>
                 <field>fitskw2</field>
                 <field>fitskw3</field>
@@ -324,6 +329,7 @@ Warning: This is a generated file - take care if editing by hand
                 <field>overscan_cols</field>
                 <field>overscan_rows</field>
                 <field>rcf</field>
+                <field>read_mode</field>
                 <field>repeat</field>
                 <field>request_type</field>
                 <field>run_number</field>
@@ -393,6 +399,7 @@ Warning: This is a generated file - take care if editing by hand
                 <field>pos2_mode</field>
                 <field>pos2_reset_spiral</field>
                 <field>rcf</field>
+                <field>read_mode</field>
                 <field>repeat</field>
                 <field>request_type</field>
                 <field>run_number</field>
@@ -911,6 +918,11 @@ Warning: This is a generated file - take care if editing by hand
                 <field>type</field>
             </ConfigSet>
         </ConfigRecord>
+        <ConfigRecord name="cc:spe:rLakeshore336">
+            <ConfigSet name="cc:spe:rLakeshore336">
+                <field>simulate</field>
+            </ConfigSet>
+        </ConfigRecord>
         <ConfigRecord name="cc:spe:rShutter">
             <ConfigSet name="cc:spe:rShutter">
                 <field>expose</field>
@@ -936,6 +948,34 @@ Warning: This is a generated file - take care if editing by hand
                 <field>type</field>
             </ConfigSet>
         </ConfigRecord>
+        <!-- From JSON file cicada_config/ghostTestUnitCC_Slave_demand.json-->
+        <ConfigRecord name="cc:tst:demand">
+            <ConfigSet name="cc:tst:demand">
+                <field>cmd_type</field>
+            </ConfigSet>
+        </ConfigRecord>
+        <ConfigRecord name="cc:tst:ici">
+            <ConfigSet name="cc:tst:ici">
+                <field>instrumentRunning</field>
+                <field>simulate</field>
+                <field>softwareEmergencyStop</field>
+            </ConfigSet>
+        </ConfigRecord>
+        <ConfigRecord name="cc:tst:tm">
+            <ConfigSet name="cc:tst:tm">
+                <field>position</field>
+                <field>simulate</field>
+                <field>type</field>
+            </ConfigSet>
+        </ConfigRecord>
+        <ConfigRecord name="cc:tst:tmAmp">
+            <ConfigSet name="cc:tst:tmAmp">
+                <field>positioning</field>
+                <field>target_enc</field>
+                <field>target_user</field>
+                <field>type</field>
+            </ConfigSet>
+        </ConfigRecord>
         <!-- From JSON file cicada_config/ghostCassegrainUnitCC_demand.json-->
         <ConfigRecord name="cc:cu">
             <ConfigSet name="cc:cu">
@@ -953,6 +993,13 @@ Warning: This is a generated file - take care if editing by hand
         <!-- From JSON file cicada_config/ghostSpectrographCC_demand.json-->
         <ConfigRecord name="cc:spe">
             <ConfigSet name="cc:spe">
+                <field>do_test</field>
+                <field>request_type</field>
+            </ConfigSet>
+        </ConfigRecord>
+        <!-- From JSON file cicada_config/ghostTestUnitCC_demand.json-->
+        <ConfigRecord name="cc:tst">
+            <ConfigSet name="cc:tst">
                 <field>do_test</field>
                 <field>request_type</field>
             </ConfigSet>

--- a/instances/ghost/src/main/config/giapi-epics-status-mapping.xml
+++ b/instances/ghost/src/main/config/giapi-epics-status-mapping.xml
@@ -25,209 +25,207 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </AlarmChannel>
         
-
   <!-- From JSON file cicada_config/ghost.json-->
   <HealthChannel>
-    <!--giapiname>inst_health_rec.health</giapiname-->
+    <!--giapiname>ghost:inst_health_rec.health</giapiname-->
     <giapiname>sad.health</giapiname>
     <epicsname>sad.health</epicsname>
   </HealthChannel>
   <SimpleChannel>
-    <!--giapiname>inst_health_rec.health_msg</giapiname-->
+    <!--giapiname>ghost:inst_health_rec.health_msg</giapiname-->
     <giapiname>sad.health_msg</giapiname>
     <epicsname>sad.health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>archiver_flag</giapiname-->
+    <!--giapiname>ghost:archiver_flag</giapiname-->
     <giapiname>sad:is.archiver_flag</giapiname>
     <epicsname>sad:is.archiver_flag</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <HealthChannel>
-    <!--giapiname>archiver_health_rec.health</giapiname-->
+    <!--giapiname>ghost:archiver_health_rec.health</giapiname-->
     <giapiname>sad:is.archiver_health</giapiname>
     <epicsname>sad:is.archiver_health</epicsname>
   </HealthChannel>
   <SimpleChannel>
-    <!--giapiname>archiver_health_rec.health_msg</giapiname-->
+    <!--giapiname>ghost:archiver_health_rec.health_msg</giapiname-->
     <giapiname>sad:is.archiver_health_msg</giapiname>
     <epicsname>sad:is.archiver_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>archiver_heartbeat</giapiname-->
+    <!--giapiname>ghost:archiver_heartbeat</giapiname-->
     <giapiname>sad:is.archiver_heartbeat</giapiname>
     <epicsname>sad:is.archiver_heartbeat</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>archiver_state</giapiname-->
+    <!--giapiname>ghost:archiver_state</giapiname-->
     <giapiname>sad:is.archiver_state</giapiname>
     <epicsname>sad:is.archiver_state</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>command_state</giapiname-->
+    <!--giapiname>ghost:command_state</giapiname-->
     <giapiname>sad:is.command_state</giapiname>
     <epicsname>sad:is.command_state</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>specific.debug</giapiname-->
+    <!--giapiname>ghost:specific.debug</giapiname-->
     <giapiname>sad:is.debug</giapiname>
     <epicsname>sad:is.debug</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>displayer_flag</giapiname-->
+    <!--giapiname>ghost:displayer_flag</giapiname-->
     <giapiname>sad:is.displayer_flag</giapiname>
     <epicsname>sad:is.displayer_flag</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <HealthChannel>
-    <!--giapiname>displayer_health_rec.health</giapiname-->
+    <!--giapiname>ghost:displayer_health_rec.health</giapiname-->
     <giapiname>sad:is.displayer_health</giapiname>
     <epicsname>sad:is.displayer_health</epicsname>
   </HealthChannel>
   <SimpleChannel>
-    <!--giapiname>displayer_health_rec.health_msg</giapiname-->
+    <!--giapiname>ghost:displayer_health_rec.health_msg</giapiname-->
     <giapiname>sad:is.displayer_health_msg</giapiname>
     <epicsname>sad:is.displayer_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>displayer_heartbeat</giapiname-->
+    <!--giapiname>ghost:displayer_heartbeat</giapiname-->
     <giapiname>sad:is.displayer_heartbeat</giapiname>
     <epicsname>sad:is.displayer_heartbeat</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>displayer_state</giapiname-->
+    <!--giapiname>ghost:displayer_state</giapiname-->
     <giapiname>sad:is.displayer_state</giapiname>
     <epicsname>sad:is.displayer_state</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <HealthChannel>
-    <!--giapiname>health_rec.health</giapiname-->
+    <!--giapiname>ghost:health_rec.health</giapiname-->
     <giapiname>sad:is.health</giapiname>
     <epicsname>sad:is.health</epicsname>
   </HealthChannel>
   <SimpleChannel>
-    <!--giapiname>health_rec.health_msg</giapiname-->
+    <!--giapiname>ghost:health_rec.health_msg</giapiname-->
     <giapiname>sad:is.health_msg</giapiname>
     <epicsname>sad:is.health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>master_flag</giapiname-->
+    <!--giapiname>ghost:master_flag</giapiname-->
     <giapiname>sad:is.master_flag</giapiname>
     <epicsname>sad:is.master_flag</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <HealthChannel>
-    <!--giapiname>master_health_rec.health</giapiname-->
+    <!--giapiname>ghost:master_health_rec.health</giapiname-->
     <giapiname>sad:is.master_health</giapiname>
     <epicsname>sad:is.master_health</epicsname>
   </HealthChannel>
   <SimpleChannel>
-    <!--giapiname>master_health_rec.health_msg</giapiname-->
+    <!--giapiname>ghost:master_health_rec.health_msg</giapiname-->
     <giapiname>sad:is.master_health_msg</giapiname>
     <epicsname>sad:is.master_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>master_heartbeat</giapiname-->
+    <!--giapiname>ghost:master_heartbeat</giapiname-->
     <giapiname>sad:is.master_heartbeat</giapiname>
     <epicsname>sad:is.master_heartbeat</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>master_state</giapiname-->
+    <!--giapiname>ghost:master_state</giapiname-->
     <giapiname>sad:is.master_state</giapiname>
     <epicsname>sad:is.master_state</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>specific.ghost_rpc_port</giapiname-->
+    <!--giapiname>ghost:specific.ghost_rpc_port</giapiname-->
     <giapiname>sad:is.rpc_port</giapiname>
     <epicsname>sad:is.rpc_port</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>script_abort</giapiname-->
+    <!--giapiname>ghost:script_abort</giapiname-->
     <giapiname>sad:is.script_abort</giapiname>
     <epicsname>sad:is.script_abort</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>script_msg</giapiname-->
+    <!--giapiname>ghost:script_msg</giapiname-->
     <giapiname>sad:is.script_msg</giapiname>
     <epicsname>sad:is.script_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>script_result</giapiname-->
+    <!--giapiname>ghost:script_result</giapiname-->
     <giapiname>sad:is.script_result</giapiname>
     <epicsname>sad:is.script_result</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>script_running</giapiname-->
+    <!--giapiname>ghost:script_running</giapiname-->
     <giapiname>sad:is.script_running</giapiname>
     <epicsname>sad:is.script_running</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>script_state</giapiname-->
+    <!--giapiname>ghost:script_state</giapiname-->
     <giapiname>sad:is.script_state</giapiname>
     <epicsname>sad:is.script_state</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>script_stop</giapiname-->
+    <!--giapiname>ghost:script_stop</giapiname-->
     <giapiname>sad:is.script_stop</giapiname>
     <epicsname>sad:is.script_stop</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>specific.ghost_server_port</giapiname-->
+    <!--giapiname>ghost:specific.ghost_server_port</giapiname-->
     <giapiname>sad:is.server_port</giapiname>
     <epicsname>sad:is.server_port</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>specific.simulation</giapiname-->
+    <!--giapiname>ghost:specific.simulation</giapiname-->
     <giapiname>sad:is.simulation</giapiname>
     <epicsname>sad:is.simulation</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-
   <!-- From JSON file cicada_config/ghostCassegrainUnitCC.json-->
   <HealthChannel>
     <!--giapiname>ghostCassegrainUnitCC:inst_ctl_health_rec.health</giapiname-->
@@ -326,7 +324,6 @@ Warning: This is a generated file - take care if editing by hand
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
-
   <!-- From JSON file cicada_config/ghostSlitUnitCC.json-->
   <HealthChannel>
     <!--giapiname>ghostSlitUnitCC:inst_ctl_health_rec.health</giapiname-->
@@ -425,7 +422,6 @@ Warning: This is a generated file - take care if editing by hand
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
-
   <!-- From JSON file cicada_config/ghostSpectrographCC.json-->
   <HealthChannel>
     <!--giapiname>ghostSpectrographCC:inst_ctl_health_rec.health</giapiname-->
@@ -524,7 +520,104 @@ Warning: This is a generated file - take care if editing by hand
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
-
+  <!-- From JSON file cicada_config/ghostTestUnitCC.json-->
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:inst_ctl_health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst.control_health</giapiname>
+    <epicsname>sad:cc:tst.control_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:inst_ctl_health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst.control_health_msg</giapiname>
+    <epicsname>sad:cc:tst.control_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:control_heartbeat</giapiname-->
+    <giapiname>sad:cc:tst.control_heartbeat</giapiname>
+    <epicsname>sad:cc:tst.control_heartbeat</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:control_state</giapiname-->
+    <giapiname>sad:cc:tst.control_state</giapiname>
+    <epicsname>sad:cc:tst.control_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:data_state</giapiname-->
+    <giapiname>sad:cc:tst.data_state</giapiname>
+    <epicsname>sad:cc:tst.data_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:specific.debug</giapiname-->
+    <giapiname>sad:cc:tst.debug</giapiname>
+    <epicsname>sad:cc:tst.debug</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:specific.simulation</giapiname-->
+    <giapiname>sad:cc:tst.hw_simulation</giapiname>
+    <epicsname>sad:cc:tst.hw_simulation</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:part_health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst.part_health</giapiname>
+    <epicsname>sad:cc:tst.part_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:part_health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst.part_health_msg</giapiname>
+    <epicsname>sad:cc:tst.part_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:slave_health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst.slave_health</giapiname>
+    <epicsname>sad:cc:tst.slave_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:slave_health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst.slave_health_msg</giapiname>
+    <epicsname>sad:cc:tst.slave_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:slave_heartbeat</giapiname-->
+    <giapiname>sad:cc:tst.slave_heartbeat</giapiname>
+    <epicsname>sad:cc:tst.slave_heartbeat</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:slave_state</giapiname-->
+    <giapiname>sad:cc:tst.slave_state</giapiname>
+    <epicsname>sad:cc:tst.slave_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst.top_health</giapiname>
+    <epicsname>sad:cc:tst.top_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst.top_health_msg</giapiname>
+    <epicsname>sad:cc:tst.top_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
   <!-- From JSON file cicada_config/ghostCassegrainUnitCC_Slave.json-->
   <HealthChannel>
     <!--giapiname>ghostCassegrainUnitCC:status.alarm_health.health</giapiname-->
@@ -614,7 +707,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.result.result</giapiname-->
     <giapiname>sad:cc:cu.result</giapiname>
     <epicsname>sad:cc:cu.result</epicsname>
     <type>INT</type>
@@ -779,6 +872,13 @@ Warning: This is a generated file - take care if editing by hand
     <type>DOUBLE</type>
     <initial>0.0</initial>
   </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostCassegrainUnitCC:status.adc1.pos.dispersion</giapiname-->
+    <giapiname>sad:cc:cu:adc1.dispersion</giapiname>
+    <epicsname>sad:cc:cu:adc1.dispersion</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
   <HealthChannel>
     <!--giapiname>ghostCassegrainUnitCC:status.adc1.health_rec.health</giapiname-->
     <giapiname>sad:cc:cu:adc1.health</giapiname>
@@ -799,7 +899,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.adc1.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.adc1.result.result</giapiname-->
     <giapiname>sad:cc:cu:adc1.result</giapiname>
     <epicsname>sad:cc:cu:adc1.result</epicsname>
     <type>INT</type>
@@ -930,7 +1030,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.adc1.a.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.adc1.a.result.result</giapiname-->
     <giapiname>sad:cc:cu:adc1a.result</giapiname>
     <epicsname>sad:cc:cu:adc1a.result</epicsname>
     <type>INT</type>
@@ -1089,7 +1189,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.adc1.b.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.adc1.b.result.result</giapiname-->
     <giapiname>sad:cc:cu:adc1b.result</giapiname>
     <epicsname>sad:cc:cu:adc1b.result</epicsname>
     <type>INT</type>
@@ -1228,6 +1328,13 @@ Warning: This is a generated file - take care if editing by hand
     <type>DOUBLE</type>
     <initial>0.0</initial>
   </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostCassegrainUnitCC:status.adc2.pos.dispersion</giapiname-->
+    <giapiname>sad:cc:cu:adc2.dispersion</giapiname>
+    <epicsname>sad:cc:cu:adc2.dispersion</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
   <HealthChannel>
     <!--giapiname>ghostCassegrainUnitCC:status.adc2.health_rec.health</giapiname-->
     <giapiname>sad:cc:cu:adc2.health</giapiname>
@@ -1248,7 +1355,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.adc2.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.adc2.result.result</giapiname-->
     <giapiname>sad:cc:cu:adc2.result</giapiname>
     <epicsname>sad:cc:cu:adc2.result</epicsname>
     <type>INT</type>
@@ -1379,7 +1486,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.adc2.a.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.adc2.a.result.result</giapiname-->
     <giapiname>sad:cc:cu:adc2a.result</giapiname>
     <epicsname>sad:cc:cu:adc2a.result</epicsname>
     <type>INT</type>
@@ -1538,7 +1645,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.adc2.b.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.adc2.b.result.result</giapiname-->
     <giapiname>sad:cc:cu:adc2b.result</giapiname>
     <epicsname>sad:cc:cu:adc2b.result</epicsname>
     <type>INT</type>
@@ -1774,7 +1881,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.result.result</giapiname-->
     <giapiname>sad:cc:cu:ici.result</giapiname>
     <epicsname>sad:cc:cu:ici.result</epicsname>
     <type>INT</type>
@@ -1842,6 +1949,13 @@ Warning: This is a generated file - take care if editing by hand
     <epicsname>sad:cc:cu:ifu1.fpy</epicsname>
     <type>DOUBLE</type>
     <initial>0.0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostCassegrainUnitCC:guide.ifu1.heartbeat</giapiname-->
+    <giapiname>sad:cc:cu:ifu1.guide_heartbeat</giapiname>
+    <epicsname>sad:cc:cu:ifu1.guide_heartbeat</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostCassegrainUnitCC:guide.ifu1.x</giapiname-->
@@ -1940,7 +2054,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ifu1.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ifu1.result.result</giapiname-->
     <giapiname>sad:cc:cu:ifu1.result</giapiname>
     <epicsname>sad:cc:cu:ifu1.result</epicsname>
     <type>INT</type>
@@ -2680,7 +2794,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ifu1.x.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ifu1.x.result.result</giapiname-->
     <giapiname>sad:cc:cu:ifu1x.result</giapiname>
     <epicsname>sad:cc:cu:ifu1x.result</epicsname>
     <type>INT</type>
@@ -2846,7 +2960,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ifu1.y.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ifu1.y.result.result</giapiname-->
     <giapiname>sad:cc:cu:ifu1y.result</giapiname>
     <epicsname>sad:cc:cu:ifu1y.result</epicsname>
     <type>INT</type>
@@ -2944,6 +3058,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostCassegrainUnitCC:guide.ifu2.heartbeat</giapiname-->
+    <giapiname>sad:cc:cu:ifu2.guide_heartbeat</giapiname>
+    <epicsname>sad:cc:cu:ifu2.guide_heartbeat</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostCassegrainUnitCC:guide.ifu2.x</giapiname-->
     <giapiname>sad:cc:cu:ifu2.guide_x</giapiname>
     <epicsname>sad:cc:cu:ifu2.guide_x</epicsname>
@@ -3012,7 +3133,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ifu2.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ifu2.result.result</giapiname-->
     <giapiname>sad:cc:cu:ifu2.result</giapiname>
     <epicsname>sad:cc:cu:ifu2.result</epicsname>
     <type>INT</type>
@@ -3458,7 +3579,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ifu2.x.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ifu2.x.result.result</giapiname-->
     <giapiname>sad:cc:cu:ifu2x.result</giapiname>
     <epicsname>sad:cc:cu:ifu2x.result</epicsname>
     <type>INT</type>
@@ -3624,7 +3745,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ifu2.y.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ifu2.y.result.result</giapiname-->
     <giapiname>sad:cc:cu:ifu2y.result</giapiname>
     <epicsname>sad:cc:cu:ifu2y.result</epicsname>
     <type>INT</type>
@@ -3685,7 +3806,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ins_io.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ins_io.result.result</giapiname-->
     <giapiname>sad:cc:cu:ins.result</giapiname>
     <epicsname>sad:cc:cu:ins.result</epicsname>
     <type>INT</type>
@@ -3713,7 +3834,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.instrumentRunning.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.instrumentRunning.result.result</giapiname-->
     <giapiname>sad:cc:cu:instrumentRunning.result</giapiname>
     <epicsname>sad:cc:cu:instrumentRunning.result</epicsname>
     <type>INT</type>
@@ -3748,7 +3869,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.softwareEmergencyStop.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.softwareEmergencyStop.result.result</giapiname-->
     <giapiname>sad:cc:cu:softwareEmergencyStop.result</giapiname>
     <epicsname>sad:cc:cu:softwareEmergencyStop.result</epicsname>
     <type>INT</type>
@@ -3951,7 +4072,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.watchdogTimeoutEnableDisable.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.watchdogTimeoutEnableDisable.result.result</giapiname-->
     <giapiname>sad:cc:cu:watchdogTimeoutEnableDisable.result</giapiname>
     <epicsname>sad:cc:cu:watchdogTimeoutEnableDisable.result</epicsname>
     <type>INT</type>
@@ -3972,7 +4093,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.watchdogTimerTrigger.result</giapiname-->
+    <!--giapiname>ghostCassegrainUnitCC:status.ici_io.watchdogTimerTrigger.result.result</giapiname-->
     <giapiname>sad:cc:cu:watchdogTimerTrigger.result</giapiname>
     <epicsname>sad:cc:cu:watchdogTimerTrigger.result</epicsname>
     <type>INT</type>
@@ -3985,8 +4106,17 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-
   <!-- From JSON file cicada_config/ghostSlitUnitCC_Slave.json-->
+  <HealthChannel>
+    <!--giapiname>ghostSlitUnitCC:status.ici_io.accessPanel.health_rec.health</giapiname-->
+    <giapiname>sad:cc:slu.accessPanel_health</giapiname>
+    <epicsname>sad:cc:slu.accessPanel_health</epicsname>
+  </HealthChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSlitUnitCC:status.ici_io.actuator24VDCPowerOn.health_rec.health</giapiname-->
+    <giapiname>sad:cc:slu.actuator24V_health</giapiname>
+    <epicsname>sad:cc:slu.actuator24V_health</epicsname>
+  </HealthChannel>
   <HealthChannel>
     <!--giapiname>ghostSlitUnitCC:status.alarm_health.health</giapiname-->
     <giapiname>sad:cc:slu.alarm_health</giapiname>
@@ -4026,7 +4156,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.result.result</giapiname-->
     <giapiname>sad:cc:slu.result</giapiname>
     <epicsname>sad:cc:slu.result</epicsname>
     <type>INT</type>
@@ -4143,7 +4273,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.cfw.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.cfw.result.result</giapiname-->
     <giapiname>sad:cc:slu:cfw.result</giapiname>
     <epicsname>sad:cc:slu:cfw.result</epicsname>
     <type>INT</type>
@@ -4267,7 +4397,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.cfw.amp.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.cfw.amp.result.result</giapiname-->
     <giapiname>sad:cc:slu:cfwAmp.result</giapiname>
     <epicsname>sad:cc:slu:cfwAmp.result</epicsname>
     <type>INT</type>
@@ -4405,7 +4535,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.fa1.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.fa1.result.result</giapiname-->
     <giapiname>sad:cc:slu:fa1.result</giapiname>
     <epicsname>sad:cc:slu:fa1.result</epicsname>
     <type>INT</type>
@@ -4529,7 +4659,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.fa1.amp.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.fa1.amp.result.result</giapiname-->
     <giapiname>sad:cc:slu:fa1Amp.result</giapiname>
     <epicsname>sad:cc:slu:fa1Amp.result</epicsname>
     <type>INT</type>
@@ -4611,7 +4741,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.fa2.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.fa2.result.result</giapiname-->
     <giapiname>sad:cc:slu:fa2.result</giapiname>
     <epicsname>sad:cc:slu:fa2.result</epicsname>
     <type>INT</type>
@@ -4735,7 +4865,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.fa2.amp.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.fa2.amp.result.result</giapiname-->
     <giapiname>sad:cc:slu:fa2Amp.result</giapiname>
     <epicsname>sad:cc:slu:fa2Amp.result</epicsname>
     <type>INT</type>
@@ -4833,7 +4963,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.ins_io.hclPowerCtl.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.ins_io.hclPowerCtl.result.result</giapiname-->
     <giapiname>sad:cc:slu:hclPowerCtl.result</giapiname>
     <epicsname>sad:cc:slu:hclPowerCtl.result</epicsname>
     <type>INT</type>
@@ -4866,7 +4996,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.ici_io.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.ici_io.result.result</giapiname-->
     <giapiname>sad:cc:slu:ici.result</giapiname>
     <epicsname>sad:cc:slu:ici.result</epicsname>
     <type>INT</type>
@@ -4899,7 +5029,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.ins_io.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.ins_io.result.result</giapiname-->
     <giapiname>sad:cc:slu:ins.result</giapiname>
     <epicsname>sad:cc:slu:ins.result</epicsname>
     <type>INT</type>
@@ -4927,7 +5057,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.ici_io.instrumentRunning.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.ici_io.instrumentRunning.result.result</giapiname-->
     <giapiname>sad:cc:slu:instrumentRunning.result</giapiname>
     <epicsname>sad:cc:slu:instrumentRunning.result</epicsname>
     <type>INT</type>
@@ -5002,7 +5132,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.smp.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.smp.result.result</giapiname-->
     <giapiname>sad:cc:slu:smp.result</giapiname>
     <epicsname>sad:cc:slu:smp.result</epicsname>
     <type>INT</type>
@@ -5126,7 +5256,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.smp.amp.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.smp.amp.result.result</giapiname-->
     <giapiname>sad:cc:slu:smpAmp.result</giapiname>
     <epicsname>sad:cc:slu:smpAmp.result</epicsname>
     <type>INT</type>
@@ -5175,7 +5305,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.ici_io.softwareEmergencyStop.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.ici_io.softwareEmergencyStop.result.result</giapiname-->
     <giapiname>sad:cc:slu:softwareEmergencyStop.result</giapiname>
     <epicsname>sad:cc:slu:softwareEmergencyStop.result</epicsname>
     <type>INT</type>
@@ -5231,7 +5361,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.ici_io.watchdogTimeoutEnableDisable.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.ici_io.watchdogTimeoutEnableDisable.result.result</giapiname-->
     <giapiname>sad:cc:slu:watchdogTimeoutEnableDisable.result</giapiname>
     <epicsname>sad:cc:slu:watchdogTimeoutEnableDisable.result</epicsname>
     <type>INT</type>
@@ -5252,7 +5382,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSlitUnitCC:status.ici_io.watchdogTimerTrigger.result</giapiname-->
+    <!--giapiname>ghostSlitUnitCC:status.ici_io.watchdogTimerTrigger.result.result</giapiname-->
     <giapiname>sad:cc:slu:watchdogTimerTrigger.result</giapiname>
     <epicsname>sad:cc:slu:watchdogTimerTrigger.result</epicsname>
     <type>INT</type>
@@ -5272,7 +5402,6 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </AlarmChannel>
-
   <!-- From JSON file cicada_config/ghostSpectrographCC_Slave.json-->
   <HealthChannel>
     <!--giapiname>ghostSpectrographCC:status.alarm_health.health</giapiname-->
@@ -5306,7 +5435,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.result.result</giapiname-->
     <giapiname>sad:cc:spe.result</giapiname>
     <epicsname>sad:cc:spe.result</epicsname>
     <type>INT</type>
@@ -5367,6 +5496,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostSpectrographCC:status.bFocus.infocus</giapiname-->
+    <giapiname>sad:cc:spe:bFocus.infocus</giapiname>
+    <epicsname>sad:cc:spe:bFocus.infocus</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostSpectrographCC:status.bFocus.position</giapiname-->
     <giapiname>sad:cc:spe:bFocus.position</giapiname>
     <epicsname>sad:cc:spe:bFocus.position</epicsname>
@@ -5374,7 +5510,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bFocus.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.bFocus.result.result</giapiname-->
     <giapiname>sad:cc:spe:bFocus.result</giapiname>
     <epicsname>sad:cc:spe:bFocus.result</epicsname>
     <type>INT</type>
@@ -5457,6 +5593,18 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.bFocus.amp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:bFocusAmp.health</giapiname>
+    <epicsname>sad:cc:spe:bFocusAmp.health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostSpectrographCC:status.bFocus.amp.health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:spe:bFocusAmp.health_msg</giapiname>
+    <epicsname>sad:cc:spe:bFocusAmp.health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostSpectrographCC:status.bFocus.amp.home.enc</giapiname-->
     <giapiname>sad:cc:spe:bFocusAmp.home_enc</giapiname>
@@ -5500,7 +5648,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bFocus.amp.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.bFocus.amp.result.result</giapiname-->
     <giapiname>sad:cc:spe:bFocusAmp.result</giapiname>
     <epicsname>sad:cc:spe:bFocusAmp.result</epicsname>
     <type>INT</type>
@@ -5560,20 +5708,27 @@ Warning: This is a generated file - take care if editing by hand
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
+  <AlarmChannel>
+    <!--giapiname>ghostSpectrographCC:status.bLakeshore336.heater.value</giapiname-->
+    <giapiname>sad:cc:spe:bLakeshore336.heater</giapiname>
+    <epicsname>sad:cc:spe:bLakeshore336.heater</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </AlarmChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bLakeshore336.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.bLakeshore336.result.result</giapiname-->
     <giapiname>sad:cc:spe:bLakeshore336.result</giapiname>
     <epicsname>sad:cc:spe:bLakeshore336.result</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-  <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bLakeshore336.setpoint</giapiname-->
+  <AlarmChannel>
+    <!--giapiname>ghostSpectrographCC:status.bLakeshore336.setpoint.value</giapiname-->
     <giapiname>sad:cc:spe:bLakeshore336.setPoint</giapiname>
     <epicsname>sad:cc:spe:bLakeshore336.setPoint</epicsname>
     <type>DOUBLE</type>
     <initial>0.0</initial>
-  </SimpleChannel>
+  </AlarmChannel>
   <SimpleChannel>
     <!--giapiname>ghostSpectrographCC:status.bLakeshore336.simulation</giapiname-->
     <giapiname>sad:cc:spe:bLakeshore336.simulation</giapiname>
@@ -5624,7 +5779,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bShutter.bladeA_Status.errorInterlock</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.bShutter.bladeA_Status.errorInterlocked</giapiname-->
     <giapiname>sad:cc:spe:bShutter.bladeAerrorInterlock</giapiname>
     <epicsname>sad:cc:spe:bShutter.bladeAerrorInterlock</epicsname>
     <type>INT</type>
@@ -5701,7 +5856,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bShutter.bladeB_Status.errorInterlock</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.bShutter.bladeB_Status.errorInterlocked</giapiname-->
     <giapiname>sad:cc:spe:bShutter.bladeBerrorInterlock</giapiname>
     <epicsname>sad:cc:spe:bShutter.bladeBerrorInterlock</epicsname>
     <type>INT</type>
@@ -5762,7 +5917,14 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bShutter.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.bShutter.open</giapiname-->
+    <giapiname>sad:cc:spe:bShutter.open</giapiname>
+    <epicsname>sad:cc:spe:bShutter.open</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostSpectrographCC:status.bShutter.result.result</giapiname-->
     <giapiname>sad:cc:spe:bShutter.result</giapiname>
     <epicsname>sad:cc:spe:bShutter.result</epicsname>
     <type>INT</type>
@@ -5795,7 +5957,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.bVacuum.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.bVacuum.result.result</giapiname-->
     <giapiname>sad:cc:spe:bVacuum.result</giapiname>
     <epicsname>sad:cc:spe:bVacuum.result</epicsname>
     <type>INT</type>
@@ -6010,7 +6172,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.ici_io.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.ici_io.result.result</giapiname-->
     <giapiname>sad:cc:spe:ici.result</giapiname>
     <epicsname>sad:cc:spe:ici.result</epicsname>
     <type>INT</type>
@@ -6052,7 +6214,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.ici_io.instrumentRunning.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.ici_io.instrumentRunning.result.result</giapiname-->
     <giapiname>sad:cc:spe:instrumentRunning.result</giapiname>
     <epicsname>sad:cc:spe:instrumentRunning.result</epicsname>
     <type>INT</type>
@@ -6092,7 +6254,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.lakeshore224.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.lakeshore224.result.result</giapiname-->
     <giapiname>sad:cc:spe:lakeshore224.result</giapiname>
     <epicsname>sad:cc:spe:lakeshore224.result</epicsname>
     <type>INT</type>
@@ -6160,7 +6322,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[0].result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[0].result.result</giapiname-->
     <giapiname>sad:cc:spe:meerstetter1.result</giapiname>
     <epicsname>sad:cc:spe:meerstetter1.result</epicsname>
     <type>INT</type>
@@ -6255,6 +6417,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[9].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter10:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter10:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[9].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter10:objectTemp.value</giapiname>
@@ -6337,6 +6504,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[10].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter11:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter11:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[10].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter11:objectTemp.value</giapiname>
@@ -6412,6 +6584,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[11].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter12:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter12:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[11].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter12:objectTemp.value</giapiname>
@@ -6487,6 +6664,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[12].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter13:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter13:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[12].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter13:objectTemp.value</giapiname>
@@ -6562,6 +6744,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[13].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter14:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter14:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[13].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter14:objectTemp.value</giapiname>
@@ -6637,6 +6824,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[14].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter15:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter15:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[14].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter15:objectTemp.value</giapiname>
@@ -6712,6 +6904,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[15].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter16:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter16:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[15].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter16:objectTemp.value</giapiname>
@@ -6787,6 +6984,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[16].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter17:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter17:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[16].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter17:objectTemp.value</giapiname>
@@ -6862,6 +7064,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[17].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter18:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter18:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[17].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter18:objectTemp.value</giapiname>
@@ -6937,6 +7144,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[18].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter19:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter19:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[18].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter19:objectTemp.value</giapiname>
@@ -6944,6 +7156,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>DOUBLE</type>
     <initial>0.0</initial>
   </AlarmChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[0].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter1:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter1:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[0].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter1:objectTemp.value</giapiname>
@@ -7087,6 +7304,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[19].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter20:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter20:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[19].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter20:objectTemp.value</giapiname>
@@ -7162,6 +7384,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[20].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter21:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter21:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[20].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter21:objectTemp.value</giapiname>
@@ -7237,6 +7464,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[21].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter22:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter22:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[21].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter22:objectTemp.value</giapiname>
@@ -7312,6 +7544,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[22].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter23:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter23:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[22].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter23:objectTemp.value</giapiname>
@@ -7387,6 +7624,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[23].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter24:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter24:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[23].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter24:objectTemp.value</giapiname>
@@ -7462,6 +7704,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[24].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter25:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter25:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[24].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter25:objectTemp.value</giapiname>
@@ -7469,6 +7716,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>DOUBLE</type>
     <initial>0.0</initial>
   </AlarmChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[1].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter2:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter2:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[1].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter2:objectTemp.value</giapiname>
@@ -7544,6 +7796,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[2].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter3:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter3:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[2].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter3:objectTemp.value</giapiname>
@@ -7619,6 +7876,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[3].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter4:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter4:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[3].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter4:objectTemp.value</giapiname>
@@ -7694,6 +7956,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[4].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter5:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter5:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[4].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter5:objectTemp.value</giapiname>
@@ -7769,6 +8036,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[5].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter6:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter6:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[5].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter6:objectTemp.value</giapiname>
@@ -7844,6 +8116,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[6].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter7:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter7:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[6].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter7:objectTemp.value</giapiname>
@@ -7919,6 +8196,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[7].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter8:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter8:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[7].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter8:objectTemp.value</giapiname>
@@ -7994,6 +8276,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[8].objectTemp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:meerstetter9:objectTemp.health</giapiname>
+    <epicsname>sad:cc:spe:meerstetter9:objectTemp.health</epicsname>
+  </HealthChannel>
   <AlarmChannel>
     <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.meerstetter[8].objectTemp.value</giapiname-->
     <giapiname>sad:cc:spe:meerstetter9:objectTemp.value</giapiname>
@@ -8021,7 +8308,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.onewire.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.onewire.result.result</giapiname-->
     <giapiname>sad:cc:spe:onewire.result</giapiname>
     <epicsname>sad:cc:spe:onewire.result</epicsname>
     <type>INT</type>
@@ -8138,6 +8425,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostSpectrographCC:status.rFocus.infocus</giapiname-->
+    <giapiname>sad:cc:spe:rFocus.infocus</giapiname>
+    <epicsname>sad:cc:spe:rFocus.infocus</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostSpectrographCC:status.rFocus.position</giapiname-->
     <giapiname>sad:cc:spe:rFocus.position</giapiname>
     <epicsname>sad:cc:spe:rFocus.position</epicsname>
@@ -8145,7 +8439,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rFocus.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rFocus.result.result</giapiname-->
     <giapiname>sad:cc:spe:rFocus.result</giapiname>
     <epicsname>sad:cc:spe:rFocus.result</epicsname>
     <type>INT</type>
@@ -8228,6 +8522,18 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSpectrographCC:status.rFocus.amp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:spe:rFocusAmp.health</giapiname>
+    <epicsname>sad:cc:spe:rFocusAmp.health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostSpectrographCC:status.rFocus.amp.health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:spe:rFocusAmp.health_msg</giapiname>
+    <epicsname>sad:cc:spe:rFocusAmp.health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostSpectrographCC:status.rFocus.amp.home.enc</giapiname-->
     <giapiname>sad:cc:spe:rFocusAmp.home_enc</giapiname>
@@ -8271,7 +8577,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0.0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rFocus.amp.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rFocus.amp.result.result</giapiname-->
     <giapiname>sad:cc:spe:rFocusAmp.result</giapiname>
     <epicsname>sad:cc:spe:rFocusAmp.result</epicsname>
     <type>INT</type>
@@ -8331,20 +8637,27 @@ Warning: This is a generated file - take care if editing by hand
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
+  <AlarmChannel>
+    <!--giapiname>ghostSpectrographCC:status.rLakeshore336.heater.value</giapiname-->
+    <giapiname>sad:cc:spe:rLakeshore336.heater</giapiname>
+    <epicsname>sad:cc:spe:rLakeshore336.heater</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </AlarmChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rLakeshore336.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rLakeshore336.result.result</giapiname-->
     <giapiname>sad:cc:spe:rLakeshore336.result</giapiname>
     <epicsname>sad:cc:spe:rLakeshore336.result</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-  <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rLakeshore336.setpoint</giapiname-->
+  <AlarmChannel>
+    <!--giapiname>ghostSpectrographCC:status.rLakeshore336.setpoint.value</giapiname-->
     <giapiname>sad:cc:spe:rLakeshore336.setPoint</giapiname>
     <epicsname>sad:cc:spe:rLakeshore336.setPoint</epicsname>
     <type>DOUBLE</type>
     <initial>0.0</initial>
-  </SimpleChannel>
+  </AlarmChannel>
   <SimpleChannel>
     <!--giapiname>ghostSpectrographCC:status.rLakeshore336.simulation</giapiname-->
     <giapiname>sad:cc:spe:rLakeshore336.simulation</giapiname>
@@ -8365,7 +8678,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rPi.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rPi.result.result</giapiname-->
     <giapiname>sad:cc:spe:rPi.result</giapiname>
     <epicsname>sad:cc:spe:rPi.result</epicsname>
     <type>INT</type>
@@ -8449,7 +8762,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rShutter.bladeA_Status.errorInterlock</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rShutter.bladeA_Status.errorInterlocked</giapiname-->
     <giapiname>sad:cc:spe:rShutter.bladeAerrorInterlock</giapiname>
     <epicsname>sad:cc:spe:rShutter.bladeAerrorInterlock</epicsname>
     <type>INT</type>
@@ -8526,7 +8839,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rShutter.bladeB_Status.errorInterlock</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rShutter.bladeB_Status.errorInterlocked</giapiname-->
     <giapiname>sad:cc:spe:rShutter.bladeBerrorInterlock</giapiname>
     <epicsname>sad:cc:spe:rShutter.bladeBerrorInterlock</epicsname>
     <type>INT</type>
@@ -8601,7 +8914,14 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rShutter.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rShutter.open</giapiname-->
+    <giapiname>sad:cc:spe:rShutter.open</giapiname>
+    <epicsname>sad:cc:spe:rShutter.open</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostSpectrographCC:status.rShutter.result.result</giapiname-->
     <giapiname>sad:cc:spe:rShutter.result</giapiname>
     <epicsname>sad:cc:spe:rShutter.result</epicsname>
     <type>INT</type>
@@ -8634,7 +8954,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.rVacuum.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.rVacuum.result.result</giapiname-->
     <giapiname>sad:cc:spe:rVacuum.result</giapiname>
     <epicsname>sad:cc:spe:rVacuum.result</epicsname>
     <type>INT</type>
@@ -8760,7 +9080,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.ici_io.softwareEmergencyStop.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.ici_io.softwareEmergencyStop.result.result</giapiname-->
     <giapiname>sad:cc:spe:softwareEmergencyStop.result</giapiname>
     <epicsname>sad:cc:spe:softwareEmergencyStop.result</epicsname>
     <type>INT</type>
@@ -8807,7 +9127,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.thermalEnclosure.result.result</giapiname-->
     <giapiname>sad:cc:spe:thermalEnclosure.result</giapiname>
     <epicsname>sad:cc:spe:thermalEnclosure.result</epicsname>
     <type>INT</type>
@@ -8931,7 +9251,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.thermoRack401.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.thermoRack401.result.result</giapiname-->
     <giapiname>sad:cc:spe:thermoRack401.result</giapiname>
     <epicsname>sad:cc:spe:thermoRack401.result</epicsname>
     <type>INT</type>
@@ -9001,7 +9321,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.ici_io.watchdogTimeoutEnableDisable.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.ici_io.watchdogTimeoutEnableDisable.result.result</giapiname-->
     <giapiname>sad:cc:spe:watchdogTimeoutEnableDisable.result</giapiname>
     <epicsname>sad:cc:spe:watchdogTimeoutEnableDisable.result</epicsname>
     <type>INT</type>
@@ -9022,7 +9342,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.ici_io.watchdogTimerTrigger.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.ici_io.watchdogTimerTrigger.result.result</giapiname-->
     <giapiname>sad:cc:spe:watchdogTimerTrigger.result</giapiname>
     <epicsname>sad:cc:spe:watchdogTimerTrigger.result</epicsname>
     <type>INT</type>
@@ -9055,7 +9375,7 @@ Warning: This is a generated file - take care if editing by hand
     <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
-    <!--giapiname>ghostSpectrographCC:status.waterLeakDetector.result</giapiname-->
+    <!--giapiname>ghostSpectrographCC:status.waterLeakDetector.result.result</giapiname-->
     <giapiname>sad:cc:spe:waterLeakDetector.result</giapiname>
     <epicsname>sad:cc:spe:waterLeakDetector.result</epicsname>
     <type>INT</type>
@@ -9075,7 +9395,340 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-
+  <!-- From JSON file cicada_config/ghostTestUnitCC_Slave.json-->
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:status.alarm_health.health</giapiname-->
+    <giapiname>sad:cc:tst.alarm_health</giapiname>
+    <epicsname>sad:cc:tst.alarm_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.alarm_health.health_msg</giapiname-->
+    <giapiname>sad:cc:tst.alarm_health_msg</giapiname>
+    <epicsname>sad:cc:tst.alarm_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.command_state</giapiname-->
+    <giapiname>sad:cc:tst.command_state</giapiname>
+    <epicsname>sad:cc:tst.command_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:status.health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst.health</giapiname>
+    <epicsname>sad:cc:tst.health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst.health_msg</giapiname>
+    <epicsname>sad:cc:tst.health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.pva_server_port</giapiname-->
+    <giapiname>sad:cc:tst.pva_server_port</giapiname>
+    <epicsname>sad:cc:tst.pva_server_port</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <AlarmChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.electronicsRackTemp1.scaledValue</giapiname-->
+    <giapiname>sad:cc:tst:electronicsRackTemp1.scaledValue</giapiname>
+    <epicsname>sad:cc:tst:electronicsRackTemp1.scaledValue</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </AlarmChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.electronicsRackTemp1.value</giapiname-->
+    <giapiname>sad:cc:tst:electronicsRackTemp1.value</giapiname>
+    <epicsname>sad:cc:tst:electronicsRackTemp1.value</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <AlarmChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.electronicsRackTemp2.scaledValue</giapiname-->
+    <giapiname>sad:cc:tst:electronicsRackTemp2.scaledValue</giapiname>
+    <epicsname>sad:cc:tst:electronicsRackTemp2.scaledValue</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </AlarmChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.electronicsRackTemp2.value</giapiname-->
+    <giapiname>sad:cc:tst:electronicsRackTemp2.value</giapiname>
+    <epicsname>sad:cc:tst:electronicsRackTemp2.value</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst:ici.health</giapiname>
+    <epicsname>sad:cc:tst:ici.health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst:ici.health_msg</giapiname>
+    <epicsname>sad:cc:tst:ici.health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.result.result</giapiname-->
+    <giapiname>sad:cc:tst:ici.result</giapiname>
+    <epicsname>sad:cc:tst:ici.result</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.simulation</giapiname-->
+    <giapiname>sad:cc:tst:ici.simulation</giapiname>
+    <epicsname>sad:cc:tst:ici.simulation</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.instrumentEnabled.value</giapiname-->
+    <giapiname>sad:cc:tst:instrumentEnabled.value</giapiname>
+    <epicsname>sad:cc:tst:instrumentEnabled.value</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.instrumentRunning.command_state</giapiname-->
+    <giapiname>sad:cc:tst:instrumentRunning.command_state</giapiname>
+    <epicsname>sad:cc:tst:instrumentRunning.command_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.instrumentRunning.result.result</giapiname-->
+    <giapiname>sad:cc:tst:instrumentRunning.result</giapiname>
+    <epicsname>sad:cc:tst:instrumentRunning.result</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.instrumentRunning.value</giapiname-->
+    <giapiname>sad:cc:tst:instrumentRunning.value</giapiname>
+    <epicsname>sad:cc:tst:instrumentRunning.value</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.instrumentSWRunning.value</giapiname-->
+    <giapiname>sad:cc:tst:instrumentSWRunning.value</giapiname>
+    <epicsname>sad:cc:tst:instrumentSWRunning.value</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.softwareEmergencyStop.command_state</giapiname-->
+    <giapiname>sad:cc:tst:softwareEmergencyStop.command_state</giapiname>
+    <epicsname>sad:cc:tst:softwareEmergencyStop.command_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.ici_io.softwareEmergencyStop.value</giapiname-->
+    <giapiname>sad:cc:tst:softwareEmergencyStop.value</giapiname>
+    <epicsname>sad:cc:tst:softwareEmergencyStop.value</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.command_state</giapiname-->
+    <giapiname>sad:cc:tst:tm.command_state</giapiname>
+    <epicsname>sad:cc:tst:tm.command_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst:tm.health</giapiname>
+    <epicsname>sad:cc:tst:tm.health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst:tm.health_msg</giapiname>
+    <epicsname>sad:cc:tst:tm.health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.position</giapiname-->
+    <giapiname>sad:cc:tst:tm.position</giapiname>
+    <epicsname>sad:cc:tst:tm.position</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.result.result</giapiname-->
+    <giapiname>sad:cc:tst:tm.result</giapiname>
+    <epicsname>sad:cc:tst:tm.result</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.command_state</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.command_state</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.command_state</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.current</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.current</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.current</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.enabled</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.enabled</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.enabled</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.evStatus</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.evStatus</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.evStatus</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.evStatusStr</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.evStatusStr</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.evStatusStr</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.fault</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.fault</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.fault</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.faultCode</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.faultCode</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.faultCode</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.faultStr</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.faultStr</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.faultStr</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.fwd_limit</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.fwd_limit</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.fwd_limit</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.health_rec.health</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.health</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.health_rec.health_msg</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.health_msg</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.home.enc</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.home_enc</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.home_enc</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.home.user</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.home_user</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.home_user</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.homed</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.homed</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.homed</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.moving</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.moving</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.moving</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.pos.enc</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.pos_enc</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.pos_enc</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.pos.user</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.pos_user</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.pos_user</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.result.result</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.result</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.result</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.flags.rev_limit</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.rev_limit</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.rev_limit</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.simulation</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.simulation</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.simulation</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.temperature</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.temperature</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.temperature</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.vel_enc</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.vel_enc</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.vel_enc</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostTestUnitCC:status.tm.amp.vel_user</giapiname-->
+    <giapiname>sad:cc:tst:tmAmp.vel_user</giapiname>
+    <epicsname>sad:cc:tst:tmAmp.vel_user</epicsname>
+    <type>DOUBLE</type>
+    <initial>0.0</initial>
+  </SimpleChannel>
   <!-- From JSON file cicada_config/ghostRed.json-->
   <SimpleChannel>
     <!--giapiname>ghostRed:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.acq</giapiname-->
@@ -9091,6 +9744,18 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.alarm_health.health</giapiname-->
+    <giapiname>sad:dc:red.alarm_health</giapiname>
+    <epicsname>sad:dc:red.alarm_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.alarm_health.health_msg</giapiname-->
+    <giapiname>sad:dc:red.alarm_health_msg</giapiname>
+    <epicsname>sad:dc:red.alarm_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostRed:Hardware_Status_u.camera_status.rcf</giapiname-->
     <giapiname>sad:dc:red.binx</giapiname>
@@ -9099,9 +9764,23 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.rcfRQ</giapiname-->
+    <giapiname>sad:dc:red.binxRQ</giapiname>
+    <epicsname>sad:dc:red.binxRQ</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostRed:Hardware_Status_u.camera_status.ccf</giapiname-->
     <giapiname>sad:dc:red.biny</giapiname>
     <epicsname>sad:dc:red.biny</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.ccfRQ</giapiname-->
+    <giapiname>sad:dc:red.binyRQ</giapiname>
+    <epicsname>sad:dc:red.binyRQ</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -9114,6 +9793,18 @@ Warning: This is a generated file - take care if editing by hand
     <!--giapiname>ghostRed:Hardware_Status_u.camera_status.health_rec.health_msg</giapiname-->
     <giapiname>sad:dc:red.camera_health_msg</giapiname>
     <epicsname>sad:dc:red.camera_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health</giapiname-->
+    <giapiname>sad:dc:red.ccd_health</giapiname>
+    <epicsname>sad:dc:red.ccd_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health_msg</giapiname-->
+    <giapiname>sad:dc:red.ccd_health_msg</giapiname>
+    <epicsname>sad:dc:red.ccd_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
@@ -9149,6 +9840,30 @@ Warning: This is a generated file - take care if editing by hand
     <epicsname>sad:dc:red.control_state</epicsname>
     <type>INT</type>
     <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.dummy.health_rec.health</giapiname-->
+    <giapiname>sad:dc:red.controller_health</giapiname>
+    <epicsname>sad:dc:red.controller_health</epicsname>
+  </HealthChannel>
+  <HealthChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.health_rec.health</giapiname-->
+    <giapiname>sad:dc:red.controller_health</giapiname>
+    <epicsname>sad:dc:red.controller_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.dummy.health_rec.health_msg</giapiname-->
+    <giapiname>sad:dc:red.controller_health_msg</giapiname>
+    <epicsname>sad:dc:red.controller_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.health_rec.health_msg</giapiname-->
+    <giapiname>sad:dc:red.controller_health_msg</giapiname>
+    <epicsname>sad:dc:red.controller_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostRed:Hardware_Status_u.camera_status.dark_time</giapiname-->
@@ -9233,9 +9948,37 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.controller_idling</giapiname-->
+    <giapiname>sad:dc:red.idling</giapiname>
+    <epicsname>sad:dc:red.idling</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_initialised</giapiname-->
+    <giapiname>sad:dc:red.initialised</giapiname>
+    <epicsname>sad:dc:red.initialised</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostRed:iteration</giapiname-->
     <giapiname>sad:dc:red.iteration</giapiname>
     <epicsname>sad:dc:red.iteration</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.last_header</giapiname-->
+    <giapiname>sad:dc:red.last_header</giapiname>
+    <epicsname>sad:dc:red.last_header</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.last_reply</giapiname-->
+    <giapiname>sad:dc:red.last_reply</giapiname>
+    <epicsname>sad:dc:red.last_reply</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -9250,6 +9993,13 @@ Warning: This is a generated file - take care if editing by hand
     <epicsname>sad:dc:red.part_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.controller_pon</giapiname-->
+    <giapiname>sad:dc:red.pon</giapiname>
+    <epicsname>sad:dc:red.pon</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostRed:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.prep</giapiname-->
@@ -9287,6 +10037,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.read_modeRQ</giapiname-->
+    <giapiname>sad:dc:red.read_modeRQ</giapiname>
+    <epicsname>sad:dc:red.read_modeRQ</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostRed:readout_target</giapiname-->
     <giapiname>sad:dc:red.readout_target</giapiname>
     <epicsname>sad:dc:red.readout_target</epicsname>
@@ -9304,6 +10061,13 @@ Warning: This is a generated file - take care if editing by hand
     <!--giapiname>ghostRed:repeat</giapiname-->
     <giapiname>sad:dc:red.repeat</giapiname>
     <epicsname>sad:dc:red.repeat</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.reply_status</giapiname-->
+    <giapiname>sad:dc:red.reply_status</giapiname>
+    <epicsname>sad:dc:red.reply_status</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -9362,6 +10126,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostRed:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.controller_swv</giapiname-->
+    <giapiname>sad:dc:red.swv</giapiname>
+    <epicsname>sad:dc:red.swv</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostRed:target</giapiname-->
     <giapiname>sad:dc:red.target</giapiname>
     <epicsname>sad:dc:red.target</epicsname>
@@ -9394,7 +10165,6 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-
   <!-- From JSON file cicada_config/ghostBlue.json-->
   <SimpleChannel>
     <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.acq</giapiname-->
@@ -9410,6 +10180,18 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.alarm_health.health</giapiname-->
+    <giapiname>sad:dc:blue.alarm_health</giapiname>
+    <epicsname>sad:dc:blue.alarm_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.alarm_health.health_msg</giapiname-->
+    <giapiname>sad:dc:blue.alarm_health_msg</giapiname>
+    <epicsname>sad:dc:blue.alarm_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.rcf</giapiname-->
     <giapiname>sad:dc:blue.binx</giapiname>
@@ -9418,9 +10200,23 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.rcfRQ</giapiname-->
+    <giapiname>sad:dc:blue.binxRQ</giapiname>
+    <epicsname>sad:dc:blue.binxRQ</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.ccf</giapiname-->
     <giapiname>sad:dc:blue.biny</giapiname>
     <epicsname>sad:dc:blue.biny</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.ccfRQ</giapiname-->
+    <giapiname>sad:dc:blue.binyRQ</giapiname>
+    <epicsname>sad:dc:blue.binyRQ</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -9433,6 +10229,18 @@ Warning: This is a generated file - take care if editing by hand
     <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.health_rec.health_msg</giapiname-->
     <giapiname>sad:dc:blue.camera_health_msg</giapiname>
     <epicsname>sad:dc:blue.camera_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health</giapiname-->
+    <giapiname>sad:dc:blue.ccd_health</giapiname>
+    <epicsname>sad:dc:blue.ccd_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health_msg</giapiname-->
+    <giapiname>sad:dc:blue.ccd_health_msg</giapiname>
+    <epicsname>sad:dc:blue.ccd_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
@@ -9469,6 +10277,16 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.dummy.health_rec.health</giapiname-->
+    <giapiname>sad:dc:blue.controller_health</giapiname>
+    <epicsname>sad:dc:blue.controller_health</epicsname>
+  </HealthChannel>
+  <HealthChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.health_rec.health</giapiname-->
+    <giapiname>sad:dc:blue.controller_health</giapiname>
+    <epicsname>sad:dc:blue.controller_health</epicsname>
+  </HealthChannel>
   <SimpleChannel>
     <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.dark_time</giapiname-->
     <giapiname>sad:dc:blue.dark_time</giapiname>
@@ -9552,9 +10370,37 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.controller_idling</giapiname-->
+    <giapiname>sad:dc:blue.idling</giapiname>
+    <epicsname>sad:dc:blue.idling</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_initialised</giapiname-->
+    <giapiname>sad:dc:blue.initialised</giapiname>
+    <epicsname>sad:dc:blue.initialised</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostBlue:iteration</giapiname-->
     <giapiname>sad:dc:blue.iteration</giapiname>
     <epicsname>sad:dc:blue.iteration</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.last_header</giapiname-->
+    <giapiname>sad:dc:blue.last_header</giapiname>
+    <epicsname>sad:dc:blue.last_header</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.last_reply</giapiname-->
+    <giapiname>sad:dc:blue.last_reply</giapiname>
+    <epicsname>sad:dc:blue.last_reply</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -9569,6 +10415,13 @@ Warning: This is a generated file - take care if editing by hand
     <epicsname>sad:dc:blue.part_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.controller_pon</giapiname-->
+    <giapiname>sad:dc:blue.pon</giapiname>
+    <epicsname>sad:dc:blue.pon</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.prep</giapiname-->
@@ -9606,6 +10459,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.read_modeRQ</giapiname-->
+    <giapiname>sad:dc:blue.read_modeRQ</giapiname>
+    <epicsname>sad:dc:blue.read_modeRQ</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostBlue:readout_target</giapiname-->
     <giapiname>sad:dc:blue.readout_target</giapiname>
     <epicsname>sad:dc:blue.readout_target</epicsname>
@@ -9623,6 +10483,13 @@ Warning: This is a generated file - take care if editing by hand
     <!--giapiname>ghostBlue:repeat</giapiname-->
     <giapiname>sad:dc:blue.repeat</giapiname>
     <epicsname>sad:dc:blue.repeat</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.reply_status</giapiname-->
+    <giapiname>sad:dc:blue.reply_status</giapiname>
+    <epicsname>sad:dc:blue.reply_status</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -9681,6 +10548,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostBlue:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.sdsu.controller_swv</giapiname-->
+    <giapiname>sad:dc:blue.swv</giapiname>
+    <epicsname>sad:dc:blue.swv</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostBlue:target</giapiname-->
     <giapiname>sad:dc:blue.target</giapiname>
     <epicsname>sad:dc:blue.target</epicsname>
@@ -9713,7 +10587,6 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-
   <!-- From JSON file cicada_config/ghostSlitViewer.json-->
   <SimpleChannel>
     <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.acq</giapiname-->
@@ -9729,6 +10602,18 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.alarm_health.health</giapiname-->
+    <giapiname>sad:dc:sv.alarm_health</giapiname>
+    <epicsname>sad:dc:sv.alarm_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.alarm_health.health_msg</giapiname-->
+    <giapiname>sad:dc:sv.alarm_health_msg</giapiname>
+    <epicsname>sad:dc:sv.alarm_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.rcf</giapiname-->
     <giapiname>sad:dc:sv.binx</giapiname>
@@ -9737,9 +10622,23 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.rcfRQ</giapiname-->
+    <giapiname>sad:dc:sv.binxRQ</giapiname>
+    <epicsname>sad:dc:sv.binxRQ</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.ccf</giapiname-->
     <giapiname>sad:dc:sv.biny</giapiname>
     <epicsname>sad:dc:sv.biny</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.ccfRQ</giapiname-->
+    <giapiname>sad:dc:sv.binyRQ</giapiname>
+    <epicsname>sad:dc:sv.binyRQ</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -9752,6 +10651,18 @@ Warning: This is a generated file - take care if editing by hand
     <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.health_rec.health_msg</giapiname-->
     <giapiname>sad:dc:sv.camera_health_msg</giapiname>
     <epicsname>sad:dc:sv.camera_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health</giapiname-->
+    <giapiname>sad:dc:sv.ccd_health</giapiname>
+    <epicsname>sad:dc:sv.ccd_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health_msg</giapiname-->
+    <giapiname>sad:dc:sv.ccd_health_msg</giapiname>
+    <epicsname>sad:dc:sv.ccd_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
@@ -9788,6 +10699,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.avt.health_rec.health</giapiname-->
+    <giapiname>sad:dc:sv.controller_health</giapiname>
+    <epicsname>sad:dc:sv.controller_health</epicsname>
+  </HealthChannel>
   <SimpleChannel>
     <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.dark_time</giapiname-->
     <giapiname>sad:dc:sv.dark_time</giapiname>
@@ -9990,6 +10906,13 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostSlitViewer:Hardware_Status_u.camera_status.controller_initialised</giapiname-->
+    <giapiname>sad:dc:sv.initialised</giapiname>
+    <epicsname>sad:dc:sv.initialised</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostSlitViewer:iteration</giapiname-->
     <giapiname>sad:dc:sv.iteration</giapiname>
     <epicsname>sad:dc:sv.iteration</epicsname>
@@ -10158,7 +11081,6 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
-
   <!-- From JSON file cicada_config/ghostGuider.json-->
   <SimpleChannel>
     <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.acq</giapiname-->
@@ -10180,6 +11102,18 @@ Warning: This is a generated file - take care if editing by hand
     <epicsname>sad:dc:ag.ag_server_port</epicsname>
     <type>INT</type>
     <initial>0</initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.alarm_health.health</giapiname-->
+    <giapiname>sad:dc:ag.alarm_health</giapiname>
+    <epicsname>sad:dc:ag.alarm_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.alarm_health.health_msg</giapiname-->
+    <giapiname>sad:dc:ag.alarm_health_msg</giapiname>
+    <epicsname>sad:dc:ag.alarm_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
   </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.specific.ghost.Ghost_Camera_Status_u.ag.background_taken</giapiname-->
@@ -10203,9 +11137,23 @@ Warning: This is a generated file - take care if editing by hand
     <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.rcfRQ</giapiname-->
+    <giapiname>sad:dc:ag.binxRQ</giapiname>
+    <epicsname>sad:dc:ag.binxRQ</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
     <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.ccf</giapiname-->
     <giapiname>sad:dc:ag.biny</giapiname>
     <epicsname>sad:dc:ag.biny</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.ccfRQ</giapiname-->
+    <giapiname>sad:dc:ag.binyRQ</giapiname>
+    <epicsname>sad:dc:ag.binyRQ</epicsname>
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
@@ -10218,6 +11166,18 @@ Warning: This is a generated file - take care if editing by hand
     <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.health_rec.health_msg</giapiname-->
     <giapiname>sad:dc:ag.camera_health_msg</giapiname>
     <epicsname>sad:dc:ag.camera_health_msg</epicsname>
+    <type>STRING</type>
+    <initial></initial>
+  </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health</giapiname-->
+    <giapiname>sad:dc:ag.ccd_health</giapiname>
+    <epicsname>sad:dc:ag.ccd_health</epicsname>
+  </HealthChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.op_status.Camera_Op_Status_u.ccd.health_rec.health_msg</giapiname-->
+    <giapiname>sad:dc:ag.ccd_health_msg</giapiname>
+    <epicsname>sad:dc:ag.ccd_health_msg</epicsname>
     <type>STRING</type>
     <initial></initial>
   </SimpleChannel>
@@ -10254,6 +11214,11 @@ Warning: This is a generated file - take care if editing by hand
     <type>INT</type>
     <initial>0</initial>
   </SimpleChannel>
+  <HealthChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.controller_status.Controller_Status_u.avt.health_rec.health</giapiname-->
+    <giapiname>sad:dc:ag.controller_health</giapiname>
+    <epicsname>sad:dc:ag.controller_health</epicsname>
+  </HealthChannel>
   <SimpleChannel>
     <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.dark_time</giapiname-->
     <giapiname>sad:dc:ag.dark_time</giapiname>
@@ -10566,6 +11531,13 @@ Warning: This is a generated file - take care if editing by hand
     <epicsname>sad:dc:ag.ifu2_threshold</epicsname>
     <type>DOUBLE</type>
     <initial>0.0</initial>
+  </SimpleChannel>
+  <SimpleChannel>
+    <!--giapiname>ghostGuider:Hardware_Status_u.camera_status.controller_initialised</giapiname-->
+    <giapiname>sad:dc:ag.initialised</giapiname>
+    <epicsname>sad:dc:ag.initialised</epicsname>
+    <type>INT</type>
+    <initial>0</initial>
   </SimpleChannel>
   <SimpleChannel>
     <!--giapiname>ghostGuider:iteration</giapiname-->

--- a/instances/ghost/src/main/config/services/edu.gemini.aspen.gmp.commands.model.executors.SequenceCommandExecutorStrategy-default.cfg
+++ b/instances/ghost/src/main/config/services/edu.gemini.aspen.gmp.commands.model.executors.SequenceCommandExecutorStrategy-default.cfg
@@ -1,0 +1,1 @@
+instrumentStartupScript=ghost.sh

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
         <relativePath>../poms/scala/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>scala-compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +17,7 @@
 
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>0.0.38-SNAPSHOT</version>
+    <version>0.0.38</version>
 
     <name>Integration Tests</name>
     <description>Integration Tests</description>

--- a/jms-activemq-broker/pom.xml
+++ b/jms-activemq-broker/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.jms</groupId>
     <artifactId>jms-activemq-broker</artifactId>
-    <version>1.2.36-SNAPSHOT</version>
+    <version>1.2.36</version>
 
     <name>ActiveMQ Broker Service</name>
     <description>A JMS Broker based on the Apache ActiveMQ</description>

--- a/jms-activemq-provider/pom.xml
+++ b/jms-activemq-provider/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.jms</groupId>
     <artifactId>jms-activemq-provider</artifactId>
-    <version>1.5.16-SNAPSHOT</version>
+    <version>1.5.16</version>
 
     <name>ActiveMQ JMS Service Provider</name>
     <description>A JMS Service Provider based on the Apache ActiveMQ</description>

--- a/jms-api/pom.xml
+++ b/jms-api/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.jms</groupId>
     <artifactId>jms-api</artifactId>
-    <version>1.5.37-SNAPSHOT</version>
+    <version>1.5.37</version>
 
     <name>Gemini JMS API</name>
     <description>The Gemini Broker JMS-based API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-osgi</artifactId>
-    <version>14.5.10-SNAPSHOT</version>
+    <version>14.5.10</version>
 
     <name>giapi-osgi</name>
 
@@ -164,32 +164,32 @@
             <dependency>
                 <groupId>edu.gemini.gmp</groupId>
                 <artifactId>gmp-top</artifactId>
-                <version>0.1.16-SNAPSHOT</version>
+                <version>0.1.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>epics-heartbeat</artifactId>
-                <version>0.4.16-SNAPSHOT</version>
+                <version>0.4.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>giapi</artifactId>
-                <version>1.0.34-SNAPSHOT</version>
+                <version>1.0.34</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.jms</groupId>
                 <artifactId>jms-api</artifactId>
-                <version>1.5.37-SNAPSHOT</version>
+                <version>1.5.37</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.jms</groupId>
                 <artifactId>jms-activemq-broker</artifactId>
-                <version>1.2.36-SNAPSHOT</version>
+                <version>1.2.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.jms</groupId>
                 <artifactId>jms-activemq-provider</artifactId>
-                <version>1.5.16-SNAPSHOT</version>
+                <version>1.5.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.external.osgi.com.cosylab.epics.caj</groupId>
@@ -204,257 +204,257 @@
             <dependency>
                 <groupId>edu.gemini.epics</groupId>
                 <artifactId>epics-api</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.epics</groupId>
                 <artifactId>epics-service</artifactId>
-                <version>0.26-SNAPSHOT</version>
+                <version>0.26</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-epics-access</artifactId>
-                <version>0.4.16-SNAPSHOT</version>
+                <version>0.4.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.cas</groupId>
                 <artifactId>cas</artifactId>
-                <version>0.3.16-SNAPSHOT</version>
+                <version>0.3.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.cas</groupId>
                 <artifactId>casdb</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>giapi-jms-util</artifactId>
-                <version>0.4.16-SNAPSHOT</version>
+                <version>0.4.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.giapi</groupId>
                 <artifactId>giapi-status-setter</artifactId>
-                <version>0.1.16-SNAPSHOT</version>
+                <version>0.1.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>giapi-status-service</artifactId>
-                <version>0.5.16-SNAPSHOT</version>
+                <version>0.5.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.gmp</groupId>
                 <artifactId>gmp-status-translator</artifactId>
-                <version>0.1.16-SNAPSHOT</version>
+                <version>0.1.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-statusdb</artifactId>
-                <version>0.2.16-SNAPSHOT</version>
+                <version>0.2.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-status-gateway</artifactId>
-                <version>0.2.36-SNAPSHOT</version>
+                <version>0.2.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-status-simulator</artifactId>
-                <version>0.3.16-SNAPSHOT</version>
+                <version>0.3.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-services</artifactId>
-                <version>0.4.19-SNAPSHOT</version>
+                <version>0.4.19</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-commands</artifactId>
-                <version>1.1.16-SNAPSHOT</version>
+                <version>1.1.17</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-command-handlers</artifactId>
-                <version>1.0.33-SNAPSHOT</version>
+                <version>1.0.33</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-commands-jms-bridge</artifactId>
-                <version>0.5.16-SNAPSHOT</version>
+                <version>0.5.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-commands-jms-client</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.giapi.clients</groupId>
                 <artifactId>giapi-clients-lib</artifactId>
-                <version>1.0.15-SNAPSHOT</version>
+                <version>1.0.15</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>giapi-test-support</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>giapi-fileevents</artifactId>
-                <version>0.2.36-SNAPSHOT</version>
+                <version>0.2.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-health</artifactId>
-                <version>1.1.16-SNAPSHOT</version>
+                <version>1.1.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-heartbeat</artifactId>
-                <version>0.5.16-SNAPSHOT</version>
+                <version>0.5.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>gmp-heartbeat-distributor-service</artifactId>
-                <version>0.4.16-SNAPSHOT</version>
+                <version>0.4.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>giapi-status-dispatcher</artifactId>
-                <version>0.3.16-SNAPSHOT</version>
+                <version>0.3.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen</groupId>
                 <artifactId>giapi-obsevents</artifactId>
-                <version>0.2.36-SNAPSHOT</version>
+                <version>0.2.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-epics-to-status</artifactId>
-                <version>0.1.30-SNAPSHOT</version>
+                <version>0.1.30</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-api</artifactId>
-                <version>0.6.19-SNAPSHOT</version>
+                <version>0.6.19</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-actors-composer</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-keywords-database</artifactId>
-                <version>0.2.36-SNAPSHOT</version>
+                <version>0.2.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-config-validator</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-datalabel-provider</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-static-header-receiver</artifactId>
-                <version>0.2.35-SNAPSHOT</version>
+                <version>0.2.35</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-seqexec-actors</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-obsevent-handler</artifactId>
-                <version>0.4.19-SNAPSHOT</version>
+                <version>0.4.19</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-instrument-status-actors</artifactId>
-                <version>0.1.36-SNAPSHOT</version>
+                <version>0.1.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-properties-actors</artifactId>
-                <version>0.1.31-SNAPSHOT</version>
+                <version>0.1.31</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-constant-actors</artifactId>
-                <version>0.2.25-SNAPSHOT</version>
+                <version>0.2.25</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-performance-monitoring</artifactId>
-                <version>0.2.33-SNAPSHOT</version>
+                <version>0.2.33</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-fits-updater</artifactId>
-                <version>0.4.21-SNAPSHOT</version>
+                <version>0.4.21</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-epics-actors</artifactId>
-                <version>0.1.37-SNAPSHOT</version>
+                <version>0.1.37</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-postprocessing-policy</artifactId>
-                <version>0.4.17-SNAPSHOT</version>
+                <version>0.4.17</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-fits-checker</artifactId>
-                <version>0.4.20-SNAPSHOT</version>
+                <version>0.4.20</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-health</artifactId>
-                <version>0.5.16-SNAPSHOT</version>
+                <version>0.5.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gds</groupId>
                 <artifactId>gds-observation-state-publisher</artifactId>
-                <version>0.4.25-SNAPSHOT</version>
+                <version>0.4.25</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-pcs-updater</artifactId>
-                <version>0.6.16-SNAPSHOT</version>
+                <version>0.6.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-tcs-context</artifactId>
-                <version>0.2.36-SNAPSHOT</version>
+                <version>0.2.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-logging</artifactId>
-                <version>0.2.36-SNAPSHOT</version>
+                <version>0.2.36</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.gmp</groupId>
                 <artifactId>gmp-commands-records</artifactId>
-                <version>0.6.14-SNAPSHOT</version>
+                <version>0.6.14</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-epics-simulator</artifactId>
-                <version>0.3.16-SNAPSHOT</version>
+                <version>0.3.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-epics-status-service</artifactId>
-                <version>0.3.16-SNAPSHOT</version>
+                <version>0.3.16</version>
             </dependency>
             <dependency>
                 <groupId>edu.gemini.aspen.gmp</groupId>
                 <artifactId>gmp-tui</artifactId>
-                <version>0.5.33-SNAPSHOT</version>
+                <version>0.5.33</version>
             </dependency>
 
             <!-- EProperties -->
@@ -1019,7 +1019,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>git@github.com:gemini-hlsw/gmp.git</url>
-        <tag>HEAD</tag>
+        <tag>v14.5.10</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen</groupId>
     <artifactId>giapi-osgi</artifactId>
-    <version>14.5.9-SNAPSHOT</version>
+    <version>14.5.10-SNAPSHOT</version>
 
     <name>giapi-osgi</name>
 

--- a/poms/compiled/pom.xml
+++ b/poms/compiled/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>shared-plugin-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>14.5.9-SNAPSHOT</version>
+    <version>14.5.10</version>
 
     <name>giapi-osgi - bundle instructions</name>
 

--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>edu.gemini.aspen</groupId>
         <artifactId>giapi-osgi</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
     <artifactId>shared-plugin-settings</artifactId>
-    <version>14.5.9-SNAPSHOT</version>
+    <version>14.5.10</version>
 
     <name>giapi-osgi - plugin configuration</name>
 

--- a/poms/scala/pom.xml
+++ b/poms/scala/pom.xml
@@ -5,12 +5,12 @@
         <relativePath>../compiled/</relativePath>
         <groupId>edu.gemini.aspen.giapi-osgi.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>14.5.9-SNAPSHOT</version>
+        <version>14.5.10</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>scala-compiled-bundle-settings</artifactId>
-    <version>14.5.9-SNAPSHOT</version>
+    <version>14.5.10</version>
 
     <name>giapi-osgi - scala bundle instructions</name>
 


### PR DESCRIPTION
This change addresses then NOANSWER issue noted in Jira 4691 where it was identified that registered handlers were not listed consistently.
It also fixes the issue where the UpdateProcesser class incorrectly destroyed the _actionList prematurely which resulted in the "I don't know about action ID..." message.
Some simplification of the verbose logging has also been done.